### PR TITLE
feat: Add OpenProt digest-based Idol interface for cryptographic hashing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,6 +1050,7 @@ dependencies = [
  "volatile-const",
 ]
 
+
 [[package]]
 name = "drv-cosmo-hf"
 version = "0.1.0"
@@ -1119,6 +1120,20 @@ dependencies = [
  "counters",
  "derive-idol-err",
  "drv-cpu-power-state",
+ "idol",
+ "idol-runtime",
+ "num-traits",
+ "userlib",
+ "zerocopy 0.8.25",
+ "zerocopy-derive 0.8.25",
+]
+
+[[package]]
+name = "drv-digest-api"
+version = "0.1.0"
+dependencies = [
+ "counters",
+ "derive-idol-err",
  "idol",
  "idol-runtime",
  "num-traits",

--- a/drv/digest-api/Cargo.toml
+++ b/drv/digest-api/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "drv-digest-api"
+version = "0.1.0"
+edition = "2021"
+
+[features]
+
+[dependencies]
+idol-runtime.workspace = true
+num-traits.workspace = true
+zerocopy.workspace = true
+zerocopy-derive.workspace = true
+
+counters = { path = "../../lib/counters" }
+derive-idol-err = { path = "../../lib/derive-idol-err" }
+userlib = { path = "../../sys/userlib" }
+
+[build-dependencies]
+idol.workspace = true
+
+[lib]
+test = false
+doctest = false
+bench = false
+
+[lints]
+workspace = true

--- a/drv/digest-api/build.rs
+++ b/drv/digest-api/build.rs
@@ -1,0 +1,8 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    idol::client::build_client_stub("../../idl/digest.idol", "client_stub.rs")?;
+    Ok(())
+}

--- a/drv/digest-api/src/lib.rs
+++ b/drv/digest-api/src/lib.rs
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! API crate for Digest server.
+
+#![no_std]
+
+use derive_idol_err::IdolError;
+use userlib::{sys_send, FromPrimitive};
+
+/// Digest algorithm sizes in 32-bit words
+pub const SHA256_WORDS: usize = 8;   // 256 bits / 32 bits = 8 words
+pub const SHA384_WORDS: usize = 12;  // 384 bits / 32 bits = 12 words  
+pub const SHA512_WORDS: usize = 16;  // 512 bits / 32 bits = 16 words
+pub const SHA3_256_WORDS: usize = 8; // 256 bits / 32 bits = 8 words
+pub const SHA3_384_WORDS: usize = 12; // 384 bits / 32 bits = 12 words
+pub const SHA3_512_WORDS: usize = 16; // 512 bits / 32 bits = 16 words
+
+/// Digest algorithm identifiers
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    zerocopy::IntoBytes,
+    zerocopy::Immutable,
+    zerocopy::KnownLayout,
+    FromPrimitive,
+)]
+#[repr(u32)]
+pub enum DigestAlgorithm {
+    Sha256 = 0,
+    Sha384 = 1,
+    Sha512 = 2,
+    Sha3_256 = 3,
+    Sha3_384 = 4,
+    Sha3_512 = 5,
+}
+
+/// A generic digest output container that mirrors the HAL trait.
+///
+/// This structure represents the output of a cryptographic digest operation.
+/// It uses a const generic parameter `N` to specify the number of 32-bit words
+/// in the digest output, allowing it to accommodate different digest sizes.
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    zerocopy::IntoBytes,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::KnownLayout,
+)]
+#[repr(C)]
+pub struct DigestOutput<const N: usize> {
+    /// The digest value as an array of 32-bit words
+    pub value: [u32; N],
+}
+
+/// Type aliases for specific digest outputs
+pub type Sha256Digest = DigestOutput<SHA256_WORDS>;
+pub type Sha384Digest = DigestOutput<SHA384_WORDS>;
+pub type Sha512Digest = DigestOutput<SHA512_WORDS>;
+pub type Sha3_256Digest = DigestOutput<SHA3_256_WORDS>;
+pub type Sha3_384Digest = DigestOutput<SHA3_384_WORDS>;
+pub type Sha3_512Digest = DigestOutput<SHA3_512_WORDS>;
+
+/// Errors that can be produced from the digest server API.
+///
+/// This enumeration mirrors the ErrorKind from the HAL trait but is adapted
+/// for use in the Hubris IPC context.
+#[derive(
+    Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, IdolError, counters::Count,
+)]
+#[repr(u32)]
+pub enum DigestError {
+    /// The input data length is not valid for the hash function.
+    InvalidInputLength = 1,
+    
+    /// The specified hash algorithm is not supported by the hardware or software implementation.
+    UnsupportedAlgorithm = 2,
+    
+    /// Failed to allocate memory for the hash computation.
+    MemoryAllocationFailure = 3,
+    
+    /// Failed to initialize the hash computation context.
+    InitializationError = 4,
+    
+    /// Error occurred while updating the hash computation with new data.
+    UpdateError = 5,
+    
+    /// Error occurred while finalizing the hash computation.
+    FinalizationError = 6,
+    
+    /// The hardware accelerator is busy and cannot process the hash computation.
+    Busy = 7,
+    
+    /// General hardware failure during hash computation.
+    HardwareFailure = 8,
+    
+    /// The specified output size is not valid for the hash function.
+    InvalidOutputSize = 9,
+    
+    /// Insufficient permissions to access the hardware or perform the hash computation.
+    PermissionDenied = 10,
+    
+    /// The hash computation context has not been initialized.
+    NotInitialized = 11,
+    
+    /// Invalid session ID provided.
+    InvalidSession = 12,
+    
+    /// Maximum number of concurrent sessions exceeded.
+    TooManySessions = 13,
+
+    /// Server restarted
+    #[idol(server_death)]
+    ServerRestarted = 100,
+}
+
+/// Helper trait to convert digest outputs to byte arrays
+pub trait DigestAsBytes {
+    /// Convert the digest to a byte array
+    fn as_bytes(&self) -> &[u8];
+}
+
+impl<const N: usize> DigestAsBytes for DigestOutput<N> {
+    fn as_bytes(&self) -> &[u8] {
+        // SAFETY: [u32; N] has the same layout as [u8; N*4] when using zerocopy
+        unsafe {
+            core::slice::from_raw_parts(
+                self.value.as_ptr() as *const u8,
+                N * 4,
+            )
+        }
+    }
+}
+
+// Include the generated client stub
+include!(concat!(env!("OUT_DIR"), "/client_stub.rs"));

--- a/idl/digest.idol
+++ b/idl/digest.idol
@@ -1,0 +1,182 @@
+// Digest IPC API
+
+Interface(
+    name: "Digest",
+    ops: {
+        "init_sha256": (
+            args: {},
+            reply: Result(
+                ok: "u32", // Returns session ID for the digest context
+                err: CLike("DigestError"),
+            ),
+        ),
+        "init_sha384": (
+            args: {},
+            reply: Result(
+                ok: "u32", // Returns session ID for the digest context
+                err: CLike("DigestError"),
+            ),
+        ),
+        "init_sha512": (
+            args: {},
+            reply: Result(
+                ok: "u32", // Returns session ID for the digest context
+                err: CLike("DigestError"),
+            ),
+        ),
+        "init_sha3_256": (
+            args: {},
+            reply: Result(
+                ok: "u32", // Returns session ID for the digest context
+                err: CLike("DigestError"),
+            ),
+        ),
+        "init_sha3_384": (
+            args: {},
+            reply: Result(
+                ok: "u32", // Returns session ID for the digest context
+                err: CLike("DigestError"),
+            ),
+        ),
+        "init_sha3_512": (
+            args: {},
+            reply: Result(
+                ok: "u32", // Returns session ID for the digest context
+                err: CLike("DigestError"),
+            ),
+        ),
+        "update": (
+            args: {
+                "session_id": "u32",
+                "len": "u32",
+            },
+            leases: {
+                "data": (type: "[u8]", read: true, max_len: Some(1024)),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("DigestError"),
+            ),
+        ),
+        "finalize_sha256": (
+            args: {
+                "session_id": "u32",
+            },
+            leases: {
+                "digest_out": (type: "[u32; 8]", write: true),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("DigestError"),
+            ),
+        ),
+        "finalize_sha384": (
+            args: {
+                "session_id": "u32",
+            },
+            leases: {
+                "digest_out": (type: "[u32; 12]", write: true),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("DigestError"),
+            ),
+        ),
+        "finalize_sha512": (
+            args: {
+                "session_id": "u32",
+            },
+            leases: {
+                "digest_out": (type: "[u32; 16]", write: true),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("DigestError"),
+            ),
+        ),
+        "finalize_sha3_256": (
+            args: {
+                "session_id": "u32",
+            },
+            leases: {
+                "digest_out": (type: "[u32; 8]", write: true),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("DigestError"),
+            ),
+        ),
+        "finalize_sha3_384": (
+            args: {
+                "session_id": "u32",
+            },
+            leases: {
+                "digest_out": (type: "[u32; 12]", write: true),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("DigestError"),
+            ),
+        ),
+        "finalize_sha3_512": (
+            args: {
+                "session_id": "u32",
+            },
+            leases: {
+                "digest_out": (type: "[u32; 16]", write: true),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("DigestError"),
+            ),
+        ),
+        "reset": (
+            args: {
+                "session_id": "u32",
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("DigestError"),
+            ),
+        ),
+        "digest_oneshot_sha256": (
+            args: {
+                "len": "u32",
+            },
+            leases: {
+                "data": (type: "[u8]", read: true, max_len: Some(1024)),
+                "digest_out": (type: "[u32; 8]", write: true),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("DigestError"),
+            ),
+        ),
+        "digest_oneshot_sha384": (
+            args: {
+                "len": "u32",
+            },
+            leases: {
+                "data": (type: "[u8]", read: true, max_len: Some(1024)),
+                "digest_out": (type: "[u32; 12]", write: true),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("DigestError"),
+            ),
+        ),
+        "digest_oneshot_sha512": (
+            args: {
+                "len": "u32",
+            },
+            leases: {
+                "data": (type: "[u8]", read: true, max_len: Some(1024)),
+                "digest_out": (type: "[u32; 16]", write: true),
+            },
+            reply: Result(
+                ok: "()",
+                err: CLike("DigestError"),
+            ),
+        ),
+    },
+)


### PR DESCRIPTION
Implements a digest API package (drv-digest-api) for the Hubris microkernel, providing type-safe IPC bindings for cryptographic hash operations.

This package bridges OpenProt's digest abstraction with Hubris's Idol interface definition language, enabling secure hash computations across service boundaries.

Key features:
- Support for SHA-2 (SHA256, SHA384, SHA512) and SHA-3 family algorithms
- Session-based hash computation with proper state management
- Zero-copy digest output types with const generic sizing
- Detailed error handling for hardware and software failures
- Generated client stubs for type-safe IPC communication

The implementation follows Hubris design patterns for driver APIs and maintains compatibility with OpenProt's digest trait abstraction while leveraging Idol's RON-based interface definitions for robust inter-service communication.

Files added:
- drv/digest-api/Cargo.toml: Package configuration and dependencies
- drv/digest-api/build.rs: Idol client stub generation
- drv/digest-api/src/lib.rs: Core types, errors, and API definitions
- Updates to Cargo.lock for new dependency integration