### PR TITLE
Ecdsa server 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2089,6 +2089,7 @@ dependencies = [
  "idol",
  "idol-runtime",
  "num-traits",
+ "openprot-hal-blocking 0.1.0 (git+https://github.com/rusty1968/openprot.git?branch=i2c-hardware)",
  "userlib",
  "zerocopy 0.8.27",
  "zerocopy-derive 0.8.27",

--- a/drv/openprot-ecdsa-api/src/lib.rs
+++ b/drv/openprot-ecdsa-api/src/lib.rs
@@ -26,29 +26,20 @@ pub enum EcdsaError {
     /// Key not found
     KeyNotFound = 2,
     
-    /// Invalid signature format or length
-    InvalidSignature = 3,
-    
-    /// Invalid hash length for the algorithm
-    InvalidHashLength = 4,
+    /// Invalid parameters (length, format, or content)
+    InvalidParameters = 3,
     
     /// Signature verification failed
-    VerificationFailed = 5,
-    
-    /// Hardware security module error
-    HsmError = 6,
-    
-    /// Buffer too small for the operation
-    BufferTooSmall = 7,
+    VerificationFailed = 4,
     
     /// Cryptographic hardware not available
-    HardwareNotAvailable = 8,
+    HardwareNotAvailable = 5,
     
     /// Key is not suitable for the requested operation
-    InvalidKeyType = 9,
+    InvalidKeyType = 6,
     
     /// Internal error in cryptographic implementation
-    InternalError = 10,
+    InternalError = 7,
 
     #[idol(server_death)]
     ServerRestarted,

--- a/drv/openprot-ecdsa-server/Cargo.toml
+++ b/drv/openprot-ecdsa-server/Cargo.toml
@@ -12,6 +12,7 @@ zerocopy-derive = { workspace = true }
 drv-openprot-ecdsa-api = { path = "../openprot-ecdsa-api" }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
 
+openprot-hal-blocking = { workspace = true }
 [build-dependencies]
 build-util = { path = "../../build/util" }
 idol = { workspace = true }

--- a/drv/openprot-ecdsa-server/src/main.rs
+++ b/drv/openprot-ecdsa-server/src/main.rs
@@ -35,8 +35,9 @@ impl idl::InOrderOpenPRoTEcdsaImpl for ServerImpl {
         _msg: &RecvMessage,
         key_id: u32,
         hash: LenLimit<Leased<R, [u8]>, 48>,
-        signature: LenLimit<Leased<W, [u8]>, 104>,
-    ) -> Result<u32, RequestError<EcdsaError>> {
+        signature: LenLimit<Leased<W, [u8]>, 96>,
+    ) -> Result<(), RequestError<EcdsaError>> {
+
         // TODO: Implement ECDSA-384 signing
         // 1. Validate key_id exists and is suitable for signing
         // 2. Validate hash is exactly 48 bytes (SHA-384)
@@ -58,8 +59,8 @@ impl idl::InOrderOpenPRoTEcdsaImpl for ServerImpl {
         &mut self,
         _msg: &RecvMessage,
         hash: LenLimit<Leased<R, [u8]>, 48>,
-        signature: LenLimit<Leased<R, [u8]>, 104>,
-        public_key: LenLimit<Leased<R, [u8]>, 97>,
+        signature: LenLimit<Leased<R, [u8]>, 96>,
+        public_key: LenLimit<Leased<R, [u8]>, 96>,
     ) -> Result<bool, RequestError<EcdsaError>> {
         // TODO: Implement ECDSA-384 verification
         // 1. Validate hash is exactly 48 bytes (SHA-384)

--- a/drv/openprot-ecdsa-server/src/main.rs
+++ b/drv/openprot-ecdsa-server/src/main.rs
@@ -11,6 +11,9 @@
 #![no_std]
 #![no_main]
 
+use openprot_hal_blocking::ecdsa::{EcdsaSign, EcdsaVerify, PublicKey, Signature, P384};
+use openprot_hal_blocking::digest::Digest;
+
 use drv_openprot_ecdsa_api::EcdsaError;
 use idol_runtime::{
     LenLimit, Leased, NotificationHandler, RequestError, R, W,
@@ -19,40 +22,64 @@ use userlib::RecvMessage;
 
 ////////////////////////////////////////////////////////////////////////////////
 
-struct ServerImpl {
-    // TODO: Add cryptographic backend (HSM, software crypto, etc.)
+/// ECDSA Server implementation variants
+enum ServerImpl<S, V> {
+    /// Verification-only server (no signing capabilities)
+    VerifierOnly { verifier: V },
+    /// Full server with both signing and verification capabilities  
+    SignerVerifier { signer: S, verifier: V },
 }
 
-impl ServerImpl {
-    fn new() -> Self {
-        Self {}
+impl<S, V> ServerImpl<S, V> {
+    /// Create a server with both signing and verification capabilities
+    fn new_with_signing(signer: S, verifier: V) -> Self {
+        Self::SignerVerifier { signer, verifier }
+    }
+    
+    /// Create a verification-only server (no signing capabilities)
+    fn new_verification_only(verifier: V) -> Self {
+        Self::VerifierOnly { verifier }
     }
 }
 
-impl idl::InOrderOpenPRoTEcdsaImpl for ServerImpl {
+
+impl<S, V> idl::InOrderOpenPRoTEcdsaImpl for ServerImpl<S, V> {
     fn ecdsa384_sign(
         &mut self,
         _msg: &RecvMessage,
-        key_id: u32,
+        _key_id: u32,
         hash: LenLimit<Leased<R, [u8]>, 48>,
-        signature: LenLimit<Leased<W, [u8]>, 96>,
+        _signature: LenLimit<Leased<W, [u8]>, 96>,
     ) -> Result<(), RequestError<EcdsaError>> {
 
-        // TODO: Implement ECDSA-384 signing
-        // 1. Validate key_id exists and is suitable for signing
-        // 2. Validate hash is exactly 48 bytes (SHA-384)
-        // 3. Load private key from secure storage
-        // 4. Perform ECDSA-384 signature generation
-        // 5. Encode signature in DER-encoded ASN.1 format
-        // 6. Write signature to output lease
-        // 7. Return actual signature length
-        
-        let mut hash_buf = [0u8; 48];
-        hash.read_range(0..48, &mut hash_buf).map_err(|_| RequestError::Runtime(EcdsaError::InternalError))?;
-        
-        // TODO: Replace with actual implementation
-        // For now, return an error indicating not implemented
-        Err(RequestError::Runtime(EcdsaError::HardwareNotAvailable))
+        // Check if we have signing capability
+        match self {
+            Self::VerifierOnly { .. } => {
+                // This server instance doesn't support signing
+                return Err(RequestError::Runtime(EcdsaError::HardwareNotAvailable));
+            }
+            Self::SignerVerifier { signer, .. } => {
+                // TODO: Implement ECDSA-384 signing using the signer
+                // 1. Validate key_id exists and is suitable for signing
+                // 2. Validate hash is exactly 48 bytes (SHA-384)
+                // 3. Load private key from secure storage
+                // 4. Perform ECDSA-384 signature generation using signer
+                // 5. Write signature to output lease
+                
+                // Validate hash parameter - must be exactly 48 bytes for SHA-384
+                if hash.len() != 48 {
+                    return Err(RequestError::Runtime(EcdsaError::InvalidParameters));
+                }
+                
+                let mut hash_buf = [0u8; 48];
+                hash.read_range(0..48, &mut hash_buf)
+                    .map_err(|_| RequestError::Runtime(EcdsaError::InvalidParameters))?;
+                                
+                // TODO: Replace with actual implementation using signer
+                // For now, return an error indicating not implemented
+                Err(RequestError::Runtime(EcdsaError::InternalError))
+            }
+        }
     }
 
     fn ecdsa384_verify(
@@ -62,35 +89,49 @@ impl idl::InOrderOpenPRoTEcdsaImpl for ServerImpl {
         signature: LenLimit<Leased<R, [u8]>, 96>,
         public_key: LenLimit<Leased<R, [u8]>, 96>,
     ) -> Result<bool, RequestError<EcdsaError>> {
-        // TODO: Implement ECDSA-384 verification
-        // 1. Validate hash is exactly 48 bytes (SHA-384)
-        // 2. Validate public key is in uncompressed SEC1 format (97 bytes)
-        // 3. Validate signature is in DER-encoded ASN.1 format
-        // 4. Parse public key from SEC1 format
-        // 5. Parse signature from DER format
-        // 6. Perform ECDSA-384 signature verification
-        // 7. Return verification result
-        
-        let mut hash_buf = [0u8; 48];
-        let mut sig_buf = [0u8; 104];
-        let mut pubkey_buf = [0u8; 97];
-        
-        hash.read_range(0..48, &mut hash_buf).map_err(|_| RequestError::Runtime(EcdsaError::InternalError))?;
-        signature.read_range(0..signature.len(), &mut sig_buf[0..signature.len()]).map_err(|_| RequestError::Runtime(EcdsaError::InternalError))?;
-        public_key.read_range(0..97, &mut pubkey_buf).map_err(|_| RequestError::Runtime(EcdsaError::InternalError))?;
-        
-        // Validate public key format (uncompressed SEC1: 0x04 + 48 bytes x + 48 bytes y)
-        if pubkey_buf[0] != 0x04 {
-            return Err(RequestError::Runtime(EcdsaError::InvalidKeyType));
+        // Validate input lengths - must be exactly the expected sizes
+        if hash.len() != 48 {
+            return Err(RequestError::Runtime(EcdsaError::InvalidParameters));
+        }
+        if signature.len() != 96 {
+            return Err(RequestError::Runtime(EcdsaError::InvalidParameters));
+        }
+        if public_key.len() != 96 {
+            return Err(RequestError::Runtime(EcdsaError::InvalidParameters));
         }
         
-        // TODO: Replace with actual implementation
+        // Read inputs from leases - these will fail gracefully if inputs are too short
+        let mut hash_buf = [0u8; 48];
+        let mut pubkey_buf = [0u8; 96];  // Raw x||y coordinates, 96 bytes
+        let mut sig_buf = [0u8; 96];     // Raw r||s signature, 96 bytes
+        
+        hash.read_range(0..48, &mut hash_buf)
+            .map_err(|_| RequestError::Runtime(EcdsaError::InvalidParameters))?;
+        public_key.read_range(0..96, &mut pubkey_buf)
+            .map_err(|_| RequestError::Runtime(EcdsaError::InvalidParameters))?;
+        signature.read_range(0..96, &mut sig_buf)
+            .map_err(|_| RequestError::Runtime(EcdsaError::InvalidParameters))?;
+
+        // Convert hash to P384 digest format (48 bytes = 12 u32 words for SHA-384)
+        let mut digest_words = [0u32; 12];
+        for (i, chunk) in hash_buf.chunks_exact(4).enumerate() {
+            digest_words[i] = u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        }
+        let digest = Digest::new(digest_words);
+        
+        // Get the verifier from either variant
+        let verifier = match self {
+            Self::VerifierOnly { verifier } => verifier,
+            Self::SignerVerifier { verifier, .. } => verifier,
+        };
+        
+        // TODO: Replace with actual implementation using verifier
         // For now, return an error indicating not implemented
         Err(RequestError::Runtime(EcdsaError::HardwareNotAvailable))
     }
 }
 
-impl NotificationHandler for ServerImpl {
+impl<S, V> NotificationHandler for ServerImpl<S, V> {
     fn current_notification_mask(&self) -> u32 {
         // No notifications needed for now
         0
@@ -105,7 +146,11 @@ impl NotificationHandler for ServerImpl {
 
 #[export_name = "main"]
 fn main() -> ! {
-    let mut server = ServerImpl::new();
+    // TODO: Replace with actual cryptographic backend
+    // For now, create a verification-only server with a placeholder verifier
+    struct PlaceholderVerifier;
+    
+    let mut server: ServerImpl<(), PlaceholderVerifier> = ServerImpl::new_verification_only(PlaceholderVerifier);
     
     let mut incoming = [0u8; idl::INCOMING_SIZE];
     loop {

--- a/idl/openprot-ecdsa.idol
+++ b/idl/openprot-ecdsa.idol
@@ -3,54 +3,96 @@
 // Data Formats:
 // 
 // ECDSA-384 Signatures:
-//   - Format: DER-encoded ASN.1 ECDSA-Sig-Value structure
-//   - Structure: SEQUENCE { r INTEGER, s INTEGER }
-//   - Size: Variable, typically 103-104 bytes, maximum 104 bytes
-//   - r and s are 384-bit integers (48 bytes each when zero-padded)
-//   - DER encoding adds ~8 bytes of ASN.1 overhead
+//   - Format: Raw signature format (r || s)
+//   - Structure: r-value || s-value
+//   - Size: Fixed 96 bytes (48 + 48)
+//   - r: 48 bytes, big-endian integer (signature r component)
+//   - s: 48 bytes, big-endian integer (signature s component)
+//   - Both r and s are in range [1, n-1] where n is the P-384 curve order
+//   - Leading zeros are preserved to maintain fixed 48-byte field size
+//   - Compliant with NIST FIPS 186-4 and SEC1 standards
 //
 // P-384 Public Keys:
-//   - Format: Uncompressed SEC1 point format
-//   - Structure: 0x04 || x-coordinate || y-coordinate
-//   - Size: 97 bytes (1 + 48 + 48)
-//   - x and y coordinates are 384-bit big-endian integers
+//   - Format: Raw affine coordinates (x || y)
+//   - Structure: x-coordinate || y-coordinate
+//   - Size: Fixed 96 bytes (48 + 48)
+//   - x: 48 bytes, big-endian integer (point x-coordinate)
+//   - y: 48 bytes, big-endian integer (point y-coordinate)
+//   - No SEC1 prefix byte (0x04) - raw coordinates only
+//   - Coordinates represent a point on the NIST P-384 elliptic curve
+//   - All coordinates use big-endian (network byte order) encoding
 //
 // SHA-384 Hashes:
-//   - Size: 48 bytes
-//   - Format: Raw binary hash output
+//   - Size: Fixed 48 bytes
+//   - Format: Raw binary hash digest output
+//   - Pre-computed by caller (this interface does not perform hashing)
+//   - Must be computed over the actual message to be signed/verified
 //
 // Key IDs:
 //   - Type: 32-bit unsigned integer
-//   - Implementation-defined mapping to actual key material
-
+//   - Implementation-defined mapping to private key material
+//   - Used only for signing operations (verify uses explicit public key)
+//   - Key storage and lifecycle management is implementation-specific
+//
+// Byte Order:
+//   - All multi-byte integers use big-endian encoding (network byte order)
+//   - This matches NIST, SEC1, and RustCrypto conventions
+//   - No byte swapping required when interfacing with standard crypto libraries
+//
+// Design Rationale:
+//   - Fixed sizes enable static allocation and predictable memory usage
+//   - Big-endian encoding ensures compatibility with cryptographic standards
+//   - Zero-copy operations possible with proper alignment
+//   - Direct compatibility with hardware crypto accelerators
 Interface(
     name: "OpenPRoTEcdsa",
     ops: {
         "ecdsa384_sign": (
-            doc: "Sign a hash using ECDSA-384 with the specified private key. Returns signature in DER-encoded ASN.1 format.",
+            doc: "Sign a hash using ECDSA-384 with the specified private key.
+                  
+                  Format: Raw signature (r || s), 96 bytes total
+                  - r: 48 bytes, big-endian integer
+                  - s: 48 bytes, big-endian integer
+                  
+                  All multi-byte values use big-endian (network byte order) encoding.",
             args: {
                 "key_id": "u32",
             },
             leases: {
-                "hash": (type: "[u8]", read: true, max_len: Some(48)), // SHA-384 hash is 48 bytes
-                "signature": (type: "[u8]", write: true, max_len: Some(104)), // DER-encoded ECDSA-384 signature (max 104 bytes)
+                "hash": (type: "[u8]", read: true, max_len: Some(48)), 
+                    // SHA-384 hash, 48 bytes
+                "signature": (type: "[u8]", write: true, max_len: Some(96)), 
+                    // Raw r || s (48 + 48 bytes, big-endian)
             },
             reply: Result(
-                ok: "u32", // actual signature length
+                ok: "()",
                 err: CLike("EcdsaError"),
             ),
         ),
         
         "ecdsa384_verify": (
-            doc: "Verify an ECDSA-384 signature against a hash using the provided public key. Expects DER-encoded ASN.1 signature format.",
+            doc: "Verify an ECDSA-384 signature against a hash using the provided public key.
+                  
+                  Signature format: Raw (r || s), 96 bytes total
+                  - r: 48 bytes, big-endian integer
+                  - s: 48 bytes, big-endian integer
+                  
+                  Public key format: Raw affine coordinates (x || y), 96 bytes total
+                  - x: 48 bytes, big-endian integer
+                  - y: 48 bytes, big-endian integer
+                  
+                  All multi-byte values use big-endian (network byte order) encoding.",
             args: {},
             leases: {
-                "hash": (type: "[u8]", read: true, max_len: Some(48)), // SHA-384 hash is 48 bytes
-                "signature": (type: "[u8]", read: true, max_len: Some(104)), // DER-encoded ECDSA-384 signature (max 104 bytes)
-                "public_key": (type: "[u8]", read: true, max_len: Some(97)), // Uncompressed SEC1 P-384 public key: 1 byte prefix + 48 bytes x + 48 bytes y
+                "hash": (type: "[u8]", read: true, max_len: Some(48)),
+                    // SHA-384 hash, 48 bytes
+                "signature": (type: "[u8]", read: true, max_len: Some(96)),
+                    // Raw r || s (48 + 48 bytes, big-endian)
+                "public_key": (type: "[u8]", read: true, max_len: Some(96)),
+                    // Raw x || y (48 + 48 bytes, big-endian)
             },
             reply: Result(
-                ok: "bool", // true if signature is valid
+                ok: "bool",
                 err: CLike("EcdsaError"),
             ),
             idempotent: true,


### PR DESCRIPTION
Refactor server implementation with enum-based capabilities and consolidated error handling
      
*Enum-based ServerImpl design*:
      - `VerifierOnly { verifier: V }` for verification-only instances
      - `SignerVerifier { signer: S, verifier: V }` for full capability servers
      - Provides compile-time safety for capability checks and eliminates runtime o
ption unwrapping
    
*Consolidated error handling*:
      - Remove redundant `InvalidSignature` and `BufferTooSmall` variants
      - Consolidate input validation under single `InvalidParameters` variant
    
