### PR TITLE
MCTP I2C transport and UART logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ast1060-mctp-i2c-echo"
+version = "0.1.0"
+dependencies = [
+ "ast1060-pac",
+ "cortex-m",
+ "cortex-m-rt",
+ "kern",
+]
+
+[[package]]
 name = "ast1060-pac"
 version = "0.1.0"
 source = "git+https://github.com/aspeedtech-bmc/ast1060-pac.git#35ce8190e9b40deff918300b69d23079ca15a3f4"
@@ -4137,17 +4147,19 @@ dependencies = [
 name = "mctp-server"
 version = "0.1.0"
 dependencies = [
- "ast1060-pac",
+ "ast1060-uart-api",
+ "ast1060-uart-log",
  "build-util",
  "cortex-m",
  "cortex-m-rt",
  "counters",
+ "drv-i2c-api",
  "embedded-io",
  "heapless 0.7.17",
  "hubpack",
  "idol",
  "idol-runtime",
- "lib-ast1060-uart",
+ "log",
  "mctp 0.2.0 (git+https://github.com/OpenPRoT/mctp-rs.git?branch=sync-features)",
  "mctp-api",
  "mctp-lib",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ast1060-uart-log"
+version = "0.1.0"
+dependencies = [
+ "ast1060-uart-api",
+ "critical-section",
+ "embedded-io",
+ "log",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ indexmap = { version = "1.4.0", default-features = false, features = ["serde-1"]
 indoc = { version = "2.0.3", default-features = false }
 itertools = { version = "0.10.5", default-features = false }
 leb128 = { version = "0.2.5", default-features = false }
+log = "0.4"
 lpc55-pac = { version = "0.4", default-features = false }
 memchr = { version = "2.4", default-features = false }
 memoffset = { version = "0.6.5", default-features = false }

--- a/app/ast1060-mctp-i2c-echo/Cargo.toml
+++ b/app/ast1060-mctp-i2c-echo/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+edition = "2021"
+readme = "README.md"
+name = "ast1060-mctp-i2c-echo"
+version = "0.1.0"
+
+[features]
+#dump = ["kern/dump"]
+jtag-halt = []
+
+[dependencies]
+ast1060-pac = { workspace = true, features = ["rt"] }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+kern = { path = "../../sys/kern" }
+
+# this lets you use `cargo fix`!
+[[bin]]
+name = "ast1060-mctp-i2c-echo"
+test = false
+doctest = false
+bench = false
+
+[lints]
+workspace = true

--- a/app/ast1060-mctp-i2c-echo/README.md
+++ b/app/ast1060-mctp-i2c-echo/README.md
@@ -1,0 +1,11 @@
+# AST1060 mctp over i2c echo example
+
+A MCTP demo/test application that runs on the Aspeed AST1030/AST1060.
+
+An echo task listens for incoming MCTP reqests with message type `1` and replies by echoing the payload.
+
+EID is statically assigned to `8` by the echo task.
+
+## Testing under Linux
+
+_TODO_

--- a/app/ast1060-mctp-i2c-echo/app.toml
+++ b/app/ast1060-mctp-i2c-echo/app.toml
@@ -1,11 +1,11 @@
-name = "ast1060-mctp-echo"
+name = "ast1060-mctp-i2c-echo"
 target = "thumbv7em-none-eabihf"
 board = "ast1060-rot"
 chip = "../../chips/ast1060"
 stacksize = 1024 
 
 [kernel]
-name = "ast1060-mctp-echo"
+name = "ast1060-mctp-i2c-echo"
 requires = {flash = 20000, ram = 3072}
 
 [tasks.jefe]
@@ -34,14 +34,12 @@ task-slots = ["mctp_server"]
 [tasks.mctp_server]
 name = "mctp-server"
 priority = 3
-max-sizes = {flash = 32768, ram = 16384}
+max-sizes = {flash = 32867, ram = 16384}
 start = true
 stacksize = 12288
-notifications = ["uart-irq", "timer", "rx-data"]
-interrupts = {"uart.irq" = "uart-irq"}
-uses = ["uart"]
-task-slots = ["uart_driver"]
-features = ["transport_serial"]
+task-slots = ["uart_driver", "i2c_driver"]
+notifications = ["rx-data", "timer"]
+features = ["serial_log", "transport_i2c"]
 
 [tasks.uart_driver]
 name = "drv-ast1060-uart"
@@ -51,3 +49,12 @@ uses = ["uart"]
 start = true
 notifications = ["uart-irq"]
 interrupts = {"uart.irq" = "uart-irq"}
+
+[tasks.i2c_driver]
+name = "drv-mock-i2c"
+priority = 2
+max-sizes = {flash = 16384, ram = 4096}
+start = true
+features = ["mock-only"]
+stacksize = 2048
+notifications = ["i2c-irq"]

--- a/app/ast1060-mctp-i2c-echo/app.toml
+++ b/app/ast1060-mctp-i2c-echo/app.toml
@@ -38,7 +38,7 @@ max-sizes = {flash = 32867, ram = 16384}
 start = true
 stacksize = 12288
 task-slots = ["uart_driver", "i2c_driver"]
-notifications = ["rx-data", "timer"]
+notifications = ["rx-data", "i2c-rx", "timer"]
 features = ["serial_log", "transport_i2c"]
 
 [tasks.uart_driver]

--- a/app/ast1060-mctp-i2c-echo/src/main.rs
+++ b/app/ast1060-mctp-i2c-echo/src/main.rs
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+#![no_main]
+
+// We have to do this if we don't otherwise use it to ensure its vector table
+// gets linked in.
+
+use ast1060_pac::Peripherals;
+use cortex_m_rt::entry;
+
+#[cfg(feature = "jtag-halt")]
+use core::ptr::{self, addr_of};
+
+#[entry]
+fn main() -> ! {
+    // This code just forces the ast1060 pac to be linked in.
+    let peripherals = unsafe { Peripherals::steal() };
+    peripherals.scu.scu000().modify(|_, w| w);
+    peripherals.scu.scu41c().modify(|_, w| {
+        // Set the JTAG pinmux to 0x1f << 25
+        w.enbl_armtmsfn_pin()
+            .bit(true)
+            .enbl_armtckfn_pin()
+            .bit(true)
+            .enbl_armtrstfn_pin()
+            .bit(true)
+            .enbl_armtdifn_pin()
+            .bit(true)
+            .enbl_armtdofn_pin()
+            .bit(true)
+    });
+
+    #[cfg(feature = "jtag-halt")]
+    jtag_halt();
+
+    // Default boot speed, until we bother raising it:
+    const CYCLES_PER_MS: u32 = 16_000;
+
+    unsafe { kern::startup::start_kernel(CYCLES_PER_MS) }
+}
+
+#[cfg(feature = "jtag-halt")]
+fn jtag_halt() {
+    static mut HALT: u32 = 1;
+
+    // This is a hack to halt the CPU in JTAG mode.
+    // It writes a value to a volatile memory location
+    // Break by jtag and set val to zero to continue.
+    loop {
+        let val;
+        unsafe {
+            val = ptr::read_volatile(addr_of!(HALT));
+        }
+
+        if val == 0 {
+            break;
+        }
+    }
+}

--- a/doc/i2c-api.adoc
+++ b/doc/i2c-api.adoc
@@ -1,0 +1,960 @@
+= I2C API Design and Requirements
+:toc: left
+:toclevels: 3
+:sectnums:
+:source-highlighter: rouge
+
+== Overview
+
+The I2C API (`drv-i2c-api`) provides a client interface for I2C communication in Hubris applications. Unlike traditional I2C APIs that only support master mode operations, this implementation extends support to **slave mode** operations required for management communication.
+
+The API is designed around Hubris's task-based architecture, using IPC to communicate with separate I2C driver tasks that control the actual hardware.
+
+== Architecture
+
+=== Component Structure
+
+[source]
+----
+Application Task               I2C Driver Task           Hardware
+    (Client)                      (Server)
+       |                             |                      |
+       | 1. Create I2cDevice         |                      |
+       |    (controller, port, addr) |                      |
+       |                             |                      |
+       | 2. read_reg() / write()     |                      |
+       |------------------------->   |                      |
+       |         (IPC)               | 3. Hardware I/O      |
+       |                             |--------------------->|
+       |                             |<---------------------|
+       | 4. Reply with data          |                      |
+       |<-------------------------|  |                      |
+       |                             |                      |
+       | 5. enable_slave_receive()   |                      |
+       |------------------------->   | 6. Configure slave   |
+       |         (IPC)               |--------------------->|
+       |                             |                      |
+       |                             | 7. Interrupt on RX   |
+       |                             |<---------------------|
+       | 8. Notification (kernel)    |                      |
+       |<----------------------------|                      |
+       | 9. get_slave_message()      |                      |
+       |------------------------->   | 10. Read FIFO        |
+       |         (IPC)               |--------------------->|
+       | 11. Message data            |                      |
+       |<-------------------------|  |                      |
+----
+
+=== Key Design Principles
+
+1. **Task Separation**: I2C drivers run as separate tasks with memory isolation
+2. **Hybrid Communication Model**: Client operations use synchronous IPC; event notifications use asynchronous kernel notifications via `sys_post()`
+3. **No IDL**: Uses raw `sys_send` instead of Idol-generated code for flexibility
+4. **Type Safety**: Leverages Rust's type system and zero-copy serialization
+5. **Interrupt-Driven**: Slave mode uses notifications instead of polling
+6. **Device Identification**: 5-tuple uniquely identifies each I2C device
+
+== Device Identification
+
+Each I2C device is identified by a 5-tuple:
+
+[source,rust]
+----
+pub struct I2cDevice {
+    pub task: TaskId,              // I2C driver task
+    pub controller: Controller,     // I2C peripheral (I2C0-I2C7)
+    pub port: PortIndex,           // Pin configuration
+    pub segment: Option<(Mux, Segment)>, // Optional multiplexer
+    pub address: u8,               // 7-bit device address
+}
+----
+
+This design allows:
+- Multiple I2C controllers on the same chip
+- Multiple port configurations per controller
+- Multiplexed buses with segments
+- Clear device addressing without ambiguity
+
+== Operation Types
+
+=== Master Mode Operations
+
+Master mode operations are defined in link:../drv/i2c-types/src/lib.rs[`drv/i2c-types/src/lib.rs`]:
+
+[source,rust]
+----
+pub enum Op {
+    WriteRead = 1,          // Standard I2C transaction
+    WriteReadBlock = 2,     // SMBus block read
+    // ... slave mode operations below
+}
+----
+
+==== WriteRead (Op 1)
+
+Standard I2C write-then-read operation for register access.
+
+**Payload Structure:**
+[source]
+----
+[0]: Device address (7-bit)
+[1]: Controller index
+[2]: Port index
+[3]: Mux/segment byte (0x00 if none, or 0x80 | (mux << 4) | segment)
+
+Lease 0: Write data (register address, etc.)
+Lease 1: Read buffer
+----
+
+**Use Cases:**
+- Reading device registers
+- Writing configuration data
+- Combined write-read transactions
+
+==== WriteReadBlock (Op 2)
+
+SMBus block read where the final read operation returns variable-length data with a length byte.
+
+**Use Cases:**
+- SMBus block protocols
+- Devices that prefix data with length
+
+=== Slave Mode Operations
+
+Slave mode enables the I2C controller to act as a responder, critical for management communication.
+
+==== ConfigureSlaveAddress (Op 3)
+
+Configure the I2C controller to respond to a specific 7-bit address.
+
+**Payload Structure:**
+[source]
+----
+[0]: Slave address (7-bit)
+[1]: Controller index
+[2]: Port index
+[3]: Reserved (0)
+----
+
+**Requirements:**
+- Address must not be reserved (see Reserved Address table)
+- Address must not already be in use
+- Controller must support slave mode
+
+**Errors:**
+- `BadSlaveAddress`: Address is reserved or invalid
+- `SlaveAddressInUse`: Address already configured
+- `SlaveNotSupported`: Hardware doesn't support slave mode
+
+==== EnableSlaveReceive (Op 4)
+
+Enable the hardware to receive messages at the configured slave address.
+
+**Payload Structure:**
+[source]
+----
+[0]: Unused (0)
+[1]: Controller index
+[2]: Port index
+[3]: Reserved (0)
+----
+
+**Behavior:**
+- Hardware begins accepting transactions to the slave address
+- Messages are buffered in hardware FIFO
+- Must be called after `ConfigureSlaveAddress`
+
+==== EnableSlaveNotification (Op 6)
+
+Enable interrupt-driven notifications when slave messages arrive.
+
+**Payload Structure:**
+[source]
+----
+[0]: Unused (0)
+[1]: Controller index
+[2]: Port index
+[3]: Reserved (0)
+
+Lease 0: Notification mask (u32)
+----
+
+**Behavior:**
+- I2C driver sends notification to calling task when messages arrive
+- Notification uses the provided mask (bitwise OR with task notifications)
+- Enables low-latency, power-efficient message reception
+- Must be called after `EnableSlaveReceive`
+
+**How Notifications Work:**
+The notification flow is indirect - the kernel does not deliver hardware interrupts directly to client tasks:
+
+1. Hardware interrupt fires → Kernel dispatches to I2C driver task
+2. Driver's interrupt handler reads message from hardware FIFO and buffers it
+3. Driver calls `sys_post(client_task_id, notification_mask)` to notify the client
+4. Kernel delivers the notification, unblocking client's `sys_recv_open()`
+5. Client calls `get_slave_message()` back to driver to retrieve buffered message
+
+The driver acts as an intermediary, translating hardware interrupts into task notifications using `sys_post`. This maintains task isolation while enabling interrupt-driven communication.
+
+**Single Subscriber Per Controller:**
+- One task can subscribe to notifications per controller/port combination
+- Different tasks can subscribe to different controllers (e.g., Task A on I2C0, Task B on I2C2)
+- Calling `enable_slave_notification()` on a controller that already has a subscriber will replace the previous subscription
+- This design matches typical RoT architecture where one task owns slave mode for each I2C controller
+
+**Task Requirements:**
+- Task must have I2C driver in `task-slots`
+- Notification bit must be in task's `notifications` array
+
+**Example Configuration:**
+[source,toml]
+----
+[tasks.message_handler]
+task-slots = ["i2c_driver"]
+notifications = ["i2c-slave-rx", "timer"]
+----
+
+==== DisableSlaveNotification (Op 7)
+
+**NEW**: Disable interrupt-driven notifications.
+
+**Payload Structure:**
+[source]
+----
+[0]: Unused (0)
+[1]: Controller index
+[2]: Port index
+[3]: Reserved (0)
+----
+
+**Behavior:**
+- Stops sending notifications on message arrival
+- Messages still buffered (can be retrieved via polling)
+- Useful for temporarily suspending notifications
+
+==== GetSlaveMessage (Op 8)
+
+Retrieve a single slave message from the hardware receive buffer.
+
+**Payload Structure:**
+[source]
+----
+[0]: Unused (0)
+[1]: Controller index
+[2]: Port index
+[3]: Reserved (0)
+
+Lease 0: Receive buffer (at least 257 bytes)
+----
+
+**Response:**
+- Returns number of bytes written to buffer
+- Returns 0 if no messages available
+
+**Message Format in Buffer:**
+[source]
+----
+[0]: Source address (7-bit I2C address of sender)
+[1]: Message length (N)
+[2..N+1]: Message data
+----
+
+**Usage:**
+- Call on notification receipt for interrupt-driven mode
+- Call periodically for polling mode (not recommended)
+- Retrieves one message per call
+
+==== DisableSlaveReceive (Op 5)
+
+Disable slave receive mode.
+
+**Payload Structure:**
+[source]
+----
+[0]: Unused (0)
+[1]: Controller index
+[2]: Port index
+[3]: Reserved (0)
+----
+
+**Behavior:**
+- Hardware stops responding to slave address
+- Pending notifications are cleared
+- Buffered messages are discarded
+
+== API Methods
+
+=== Master Mode Methods
+
+Location: link:../drv/i2c-api/src/lib.rs[`drv/i2c-api/src/lib.rs`]
+
+==== read_reg<R, V>()
+
+Read a typed register value from a device.
+
+[source,rust]
+----
+pub fn read_reg<R, V>(&self, reg: R) -> Result<V, ResponseCode>
+where
+    R: IntoBytes + Immutable,
+    V: IntoBytes + FromBytes,
+----
+
+**Example:**
+[source,rust]
+----
+let temp: u16 = device.read_reg(0x00u8)?;
+----
+
+==== write<V>()
+
+Write data to a device.
+
+[source,rust]
+----
+pub fn write<V: IntoBytes + Immutable>(&self, value: V) -> Result<(), ResponseCode>
+----
+
+==== write_read_reg<R, V>()
+
+Combined write-then-read transaction.
+
+[source,rust]
+----
+pub fn write_read_reg<R, V>(
+    &self,
+    reg: R,
+    value: V,
+) -> Result<(), ResponseCode>
+----
+
+=== Slave Mode Methods
+
+==== configure_slave_address()
+
+Configure the controller to respond as a slave.
+
+[source,rust]
+----
+pub fn configure_slave_address(&self, slave_address: u8) -> Result<(), ResponseCode>
+----
+
+**Example:**
+[source,rust]
+----
+let device = I2cDevice::new(i2c_task, Controller::I2C1, PortIndex(0), None, 0x1D);
+device.configure_slave_address(0x1D)?;
+----
+
+==== enable_slave_receive()
+
+Begin buffering incoming slave messages.
+
+[source,rust]
+----
+pub fn enable_slave_receive(&self) -> Result<(), ResponseCode>
+----
+
+==== enable_slave_notification()
+
+Enable interrupt-driven notifications.
+
+[source,rust]
+----
+pub fn enable_slave_notification(&self, notification_mask: u32) -> Result<(), ResponseCode>
+----
+
+**Example:**
+[source,rust]
+----
+const I2C_RX_NOTIF: u32 = 0x0001;
+device.enable_slave_notification(I2C_RX_NOTIF)?;
+
+// In event loop
+loop {
+    let msg = sys_recv_open(&mut buf, I2C_RX_NOTIF);
+    if msg.sender == TaskId::KERNEL && (msg.operation & I2C_RX_NOTIF) != 0 {
+        let slave_msg = device.get_slave_message()?;
+        process(slave_msg);
+    }
+}
+----
+
+==== disable_slave_notification()
+
+Disable interrupt-driven notifications.
+
+[source,rust]
+----
+pub fn disable_slave_notification(&self) -> Result<(), ResponseCode>
+----
+
+==== get_slave_message()
+
+**NEW**: Retrieve one message from hardware buffer.
+
+[source,rust]
+----
+pub fn get_slave_message(&self) -> Result<SlaveMessage, ResponseCode>
+----
+
+**Returns:**
+- `Ok(SlaveMessage)`: Message retrieved successfully
+- `Err(NoSlaveMessage)`: No message available
+- `Err(...)`: Other errors
+
+==== disable_slave_receive()
+
+Stop slave mode operation.
+
+[source,rust]
+----
+pub fn disable_slave_receive(&self) -> Result<(), ResponseCode>
+----
+
+=== Deprecated Methods
+
+==== check_slave_buffer()
+
+**DEPRECATED**: Use `get_slave_message()` with notifications instead.
+
+[source,rust]
+----
+#[deprecated(since = "0.2.0")]
+pub fn check_slave_buffer(&self, buffer: &mut [u8]) -> Result<usize, ResponseCode>
+----
+
+**Why Deprecated:**
+- Requires polling (inefficient)
+- High latency
+- Wastes CPU cycles
+- Poor power efficiency
+
+==== get_slave_messages()
+
+**DEPRECATED**: Use `get_slave_message()` directly.
+
+[source,rust]
+----
+#[deprecated(since = "0.2.0")]
+pub fn get_slave_messages(&self, messages: &mut [SlaveMessage]) -> Result<usize, ResponseCode>
+----
+
+**Why Deprecated:**
+- Polling-based
+- Multi-message retrieval not needed with notifications
+
+== Error Codes
+
+Defined in link:../drv/i2c-types/src/lib.rs[`drv/i2c-types/src/lib.rs`]:
+
+[cols="1,3"]
+|===
+|Error Code |Description
+
+|`BadResponse`
+|Invalid response from server
+
+|`BadArg`
+|Invalid argument in request
+
+|`NoDevice`
+|I2C device doesn't exist
+
+|`BadController`
+|Invalid controller index
+
+|`ReservedAddress`
+|Address is reserved by I2C spec
+
+|`BadPort`
+|Invalid port index
+
+|`NoRegister`
+|Device doesn't have requested register
+
+|`BusReset`
+|I2C bus was reset during operation
+
+|`BusLocked`
+|I2C bus locked up and was reset
+
+|`ControllerBusy`
+|Controller appeared busy and was reset
+
+|`BusError`
+|General I2C bus error
+
+|`OperationNotSupported`
+|Operation not supported on this hardware
+
+|`TooMuchData`
+|Data exceeds buffer capacity
+
+|`SlaveAddressInUse`
+|Slave address already configured
+
+|`SlaveNotSupported`
+|Slave mode not supported on controller
+
+|`SlaveNotEnabled`
+|Slave receive not enabled
+
+|`SlaveBufferFull`
+|Hardware buffer full, messages dropped
+
+|`BadSlaveAddress`
+|Invalid slave address (reserved or out of range)
+
+|`SlaveConfigurationFailed`
+|Hardware failed to configure slave mode
+
+|`NoSlaveMessage`
+|No slave message available to retrieve
+
+|`NotificationFailed`
+|Failed to register notification
+|===
+
+== Reserved I2C Addresses
+
+Per I2C specification, certain addresses are reserved:
+
+[cols="1,2,3"]
+|===
+|Address (7-bit) |Binary |Purpose
+
+|0x00
+|0000000
+|General Call
+
+|0x01
+|0000001
+|CBUS Address
+
+|0x02
+|0000010
+|Future Bus Reserved
+
+|0x03
+|0000011
+|Future Purposes
+
+|0x04-0x07
+|000010x
+|High Speed Reserved
+
+|0x78-0x7B
+|111110x
+|10-bit Addressing
+
+|0x7C-0x7F
+|111111x
+|Reserved
+|===
+
+The API will reject attempts to use reserved addresses in `configure_slave_address()`.
+
+== Usage Patterns
+
+=== Standard Master Operation
+
+[source,rust]
+----
+use drv_i2c_api::*;
+use userlib::TaskId;
+
+// Create device handle
+let sensor = I2cDevice::new(
+    i2c_task,
+    Controller::I2C1,
+    PortIndex(0),
+    None,  // No multiplexer
+    0x48,  // Temperature sensor address
+);
+
+// Read temperature register
+let temp: u16 = sensor.read_reg(0x00u8)?;
+
+// Write configuration
+sensor.write_read_reg(0x01u8, 0x80u8)?;
+----
+
+=== Interrupt-Driven Slave Mode (Single Subscriber)
+
+[source,rust]
+----
+use drv_i2c_api::*;
+use userlib::*;
+
+task_slot!(I2C, i2c_driver);
+
+const I2C_RX_NOTIF: u32 = 0x0001;
+
+fn main() -> ! {
+    // Setup slave mode
+    let device = I2cDevice::new(
+        I2C.get_task_id(),
+        Controller::I2C1,
+        PortIndex(0),
+        None,
+        0x1D,  // Our slave address
+    );
+    
+    device.configure_slave_address(0x1D).unwrap_lite();
+    device.enable_slave_receive().unwrap_lite();
+    device.enable_slave_notification(I2C_RX_NOTIF).unwrap_lite();
+    
+    let mut msg_buf = [0u8; 256];
+    
+    loop {
+        let msg = sys_recv_open(&mut msg_buf, I2C_RX_NOTIF);
+        
+        if msg.sender == TaskId::KERNEL 
+            && (msg.operation & I2C_RX_NOTIF) != 0 
+        {
+            // Notification: message arrived
+            match device.get_slave_message() {
+                Ok(slave_msg) => {
+                    // Process immediately
+                    let source = slave_msg.source_address;
+                    let data = slave_msg.data();
+                    handle_message(source, data);
+                }
+                Err(ResponseCode::NoSlaveMessage) => {
+                    // Spurious notification, continue
+                }
+                Err(e) => {
+                    // Handle error
+                }
+            }
+        }
+    }
+}
+
+fn handle_message(source: u8, data: &[u8]) {
+    // Process received message
+}
+----
+
+=== Multiple I2C Controllers
+
+Different tasks can use slave mode on different I2C controllers independently.
+
+**Architecture:**
+
+[source]
+----
+Hardware I2C Controllers
+    |
+    +-- I2C0 Controller
+    |       |
+    +-- I2C2 Controller
+            |
+            v
+   I2C Driver Task (ONE task - controls all hardware)
+            |
+            | (notifications via sys_post)
+            |
+       +----+----+
+       |         |
+       v         v
+    Task A    Task B
+  (I2C0 slave) (I2C2 slave)
+----
+
+**Key Points:**
+- One I2C driver task manages **all I2C controllers** (I2C0, I2C1, I2C2, etc.)
+- Each controller can have **one task subscribed** to its slave notifications
+- Task A uses I2C0, Task B uses I2C2 - no conflict
+- Controllers operate independently
+
+**Example Implementation:**
+
+[source,rust]
+----
+// Task A: Uses I2C0 for slave communication
+task_slot!(I2C, i2c_driver);
+const I2C0_NOTIF: u32 = 0x0001;
+
+fn task_a_main() -> ! {
+    let i2c0_dev = I2cDevice::new(
+        I2C.get_task_id(),     // Driver task (controls all hardware)
+        Controller::I2C0,      // Uses I2C0 controller
+        PortIndex(0),
+        None,
+        0x1D,
+    );
+    
+    // Configure I2C0 as slave
+    i2c0_dev.configure_slave_address(0x1D).unwrap_lite();
+    i2c0_dev.enable_slave_receive().unwrap_lite();
+    i2c0_dev.enable_slave_notification(I2C0_NOTIF).unwrap_lite();
+    
+    let mut buf = [0u8; 256];
+    loop {
+        let msg = sys_recv_open(&mut buf, I2C0_NOTIF);
+        if msg.sender == TaskId::KERNEL && (msg.operation & I2C0_NOTIF) != 0 {
+            if let Ok(slave_msg) = i2c0_dev.get_slave_message() {
+                handle_i2c0_message(slave_msg.data());
+            }
+        }
+    }
+}
+
+// Task B: Uses I2C2 for slave communication (independent of Task A)
+task_slot!(I2C, i2c_driver);
+const I2C2_NOTIF: u32 = 0x0001;
+
+fn task_b_main() -> ! {
+    let i2c2_dev = I2cDevice::new(
+        I2C.get_task_id(),     // Same driver task
+        Controller::I2C2,      // Uses I2C2 controller (different from Task A)
+        PortIndex(0),
+        None,
+        0x20,
+    );
+    
+    // Configure I2C2 as slave
+    i2c2_dev.configure_slave_address(0x20).unwrap_lite();
+    i2c2_dev.enable_slave_receive().unwrap_lite();
+    i2c2_dev.enable_slave_notification(I2C2_NOTIF).unwrap_lite();
+    
+    let mut buf = [0u8; 256];
+    loop {
+        let msg = sys_recv_open(&mut buf, I2C2_NOTIF);
+        if msg.sender == TaskId::KERNEL && (msg.operation & I2C2_NOTIF) != 0 {
+            if let Ok(slave_msg) = i2c2_dev.get_slave_message() {
+                handle_i2c2_message(slave_msg.data());
+            }
+        }
+    }
+}
+----
+
+**Flow:**
+1. Master sends to I2C0 address 0x1D → Task A receives notification
+2. Master sends to I2C2 address 0x20 → Task B receives notification
+3. Controllers are independent - no interference between Task A and Task B
+
+== Design Rationale
+
+=== Why Not Use Idol?
+
+The I2C API uses raw `sys_send` instead of Idol-generated IPC for several reasons:
+
+1. **Flexibility**: Variable-length lease handling without code generation complexity
+2. **Legacy**: Predates some Idol features, works well
+3. **Performance**: Direct control over serialization and IPC layout
+4. **Simplicity**: Easier to understand for embedded developers
+
+However, future work might consider Idol for consistency with other APIs.
+
+=== Why Single Subscriber Per Controller?
+
+The API uses a single subscriber per controller/port design:
+
+**Rationale:**
+- **Simplicity**: Single `Option<(TaskId, u32)>` per controller - no array management
+- **Clear Ownership**: One task owns slave mode for each controller
+- **Matches Typical Usage**: RoT systems typically have one protocol handler per I2C bus
+- **Independent Controllers**: Different tasks can use different controllers without conflict
+
+**Typical Architecture:**
+- Task A uses I2C0 for management communication
+- Task B uses I2C2 for configuration access  
+- No subscription conflict - different controllers
+
+**If Multiple Tasks Need Same Controller:**
+Use a single owner task that forwards messages to other tasks via application-level IPC based on message content/type.
+
+=== Why Separate Operations for Notifications?
+
+Rather than automatically enabling notifications with `enable_slave_receive()`, we use a separate operation:
+
+**Advantages:**
+- Allows polling mode without notifications (backwards compatible)
+- Client controls when notifications start (after setup complete)
+- Can change notification mask without disabling slave mode
+- Clear separation of concerns
+
+**Implementation:**
+[source,rust]
+----
+device.enable_slave_receive()?;      // Hardware starts receiving
+device.enable_slave_notification(mask)?;  // Notifications enabled
+----
+
+=== Why Single Message Retrieval?
+
+`GetSlaveMessage` returns one message at a time instead of batching multiple messages:
+
+**Rationale:**
+- Natural for interrupt-driven processing (one notification → one message)
+- Simplifies buffer management
+- Reduces latency (process immediately)
+- Prevents stale data accumulation
+- Matches hardware FIFO behavior
+
+**Performance:**
+- Each notification typically corresponds to one message received
+- Subsequent messages trigger new notifications
+- No need to poll for remaining messages
+
+=== Why Deprecate Instead of Remove?
+
+Old polling methods are deprecated but not removed:
+
+**Rationale:**
+- Backwards compatibility with existing code
+- Allows gradual migration
+- Provides fallback if hardware doesn't support interrupts
+- Clear migration path with deprecation warnings
+
+## Requirements for Driver Implementation
+
+I2C driver tasks implementing this API must:
+
+=== Required Operations
+
+1. **Implement all Op enum variants** defined in `drv-i2c-types`
+2. **Handle IPC marshalling** for 5-tuple device identification
+3. **Support leases** for variable-length data transfer
+4. **Return proper error codes** from `ResponseCode` enum
+
+=== Slave Mode Requirements
+
+1. **Hardware Configuration**:
+   - Configure slave address in I2C controller
+   - Enable slave receive mode in hardware
+   - Configure receive FIFO or buffers
+
+2. **Interrupt Handling**:
+   - Register slave RX interrupt handler
+   - Read message data from hardware on interrupt
+   - Store notification mask per controller/port
+
+3. **Notification Delivery**:
+   - Send notification to client task on message arrival using `sys_post(client_task, mask)`
+   - Track which task to notify (stored during `EnableSlaveNotification`)
+   - Handle spurious interrupts gracefully
+   - Note: Driver acts as intermediary between hardware interrupt and client notification
+
+4. **Message Buffering**:
+   - Buffer at least one complete message
+   - Handle hardware FIFO overflow
+   - Implement proper flow control
+
+5. **State Management**:
+   - Track slave address per controller/port
+   - Track notification state per controller/port
+   - Handle task restarts/generation changes
+
+=== Error Handling Requirements
+
+1. **Bus Errors**: Reset and recover from bus lockups
+2. **Invalid Addresses**: Reject reserved addresses
+3. **Resource Conflicts**: Detect address/port conflicts
+4. **Hardware Limitations**: Report unsupported features clearly
+
+=== Example Driver Skeleton
+
+[source,rust]
+----
+fn handle_enable_slave_notification(
+    controller: Controller,
+    port: PortIndex,
+    notification_mask: u32,
+    caller_task: TaskId,
+) -> Result<(), ResponseCode> {
+    // 1. Validate controller supports slave mode
+    if !hardware_supports_slave(controller) {
+        return Err(ResponseCode::SlaveNotSupported);
+    }
+    
+    // 2. Store notification info
+    self.slave_notifications
+        .insert((controller, port), (caller_task, notification_mask));
+    
+    // 3. Enable interrupt in hardware
+    hardware_enable_slave_rx_interrupt(controller)?;
+    
+    Ok(())
+}
+
+fn slave_rx_interrupt_handler(&mut self, controller: Controller) {
+    // 1. Read message from hardware FIFO
+    let message = hardware_read_slave_message(controller);
+    
+    // 2. Buffer the message
+    self.slave_buffers.insert(controller, message);
+    
+    // 3. Post notification to client
+    if let Some((task, mask)) = self.slave_notifications.get(controller) {
+        sys_post(*task, *mask);
+    }
+}
+----
+
+== Future Enhancements
+
+=== Potential Improvements
+
+1. **Multi-Address Slave Mode**:
+   - Support multiple slave addresses per controller
+   - Useful for address translation or proxying
+
+2. **SMBus ARP Support**:
+   - Address Resolution Protocol
+   - Dynamic address assignment
+
+3. **Clock Stretching Control**:
+   - Fine-grained control over clock stretching behavior
+   - Timeout configuration
+
+4. **Enhanced Diagnostics**:
+   - Transaction counters
+   - Error statistics
+   - Performance metrics
+
+5. **DMA Support**:
+   - Large transfer optimization
+   - Reduced CPU overhead
+
+6. **Multi-Master Arbitration**:
+   - Better support for multi-master scenarios
+   - Arbitration loss handling
+
+=== Migration to Idol
+
+Future versions might migrate to Idol for consistency:
+
+**Advantages:**
+- Automatic client/server stub generation
+- Type-safe IPC
+- Standard error handling
+- Built-in retry logic
+
+**Challenges:**
+- Lease handling complexity
+- Migration path for existing code
+- Performance implications
+
+== Related Documentation
+
+- link:ipc.adoc[Hubris IPC System]
+- link:guide/drivers.adoc[Driver Development Guide]
+- link:guide/servers.adoc[Server Implementation Guide]
+
+== Conclusion
+
+The I2C API provides a robust, type-safe interface for I2C communication in Hubris applications. The recent addition of interrupt-driven slave mode support enables efficient implementation of management communication while maintaining backwards compatibility with polling-based code.
+
+Key design decisions prioritize:
+- **Safety**: Memory isolation and type safety
+- **Performance**: Interrupt-driven operation
+- **Flexibility**: Support for both master and slave modes
+- **Maintainability**: Clear operation semantics and error handling
+- **Compatibility**: Gradual migration path from polling to notifications
+
+This design serves as a foundation for reliable I2C communication in embedded systems requiring both traditional peripheral access and modern management protocols.

--- a/doc/i2c-api.adoc
+++ b/doc/i2c-api.adoc
@@ -30,18 +30,26 @@ Application Task               I2C Driver Task           Hardware
        | 4. Reply with data          |                      |
        |<-------------------------|  |                      |
        |                             |                      |
-       | 5. enable_slave_receive()   |                      |
-       |------------------------->   | 6. Configure slave   |
+       | 5. configure_slave_address()|                      |
+       |------------------------->   | 6. Set slave addr    |
        |         (IPC)               |--------------------->|
        |                             |                      |
-       |                             | 7. Interrupt on RX   |
-       |                             |<---------------------|
-       | 8. Notification (kernel)    |                      |
-       |<----------------------------|                      |
-       | 9. get_slave_message()      |                      |
-       |------------------------->   | 10. Read FIFO        |
+       | 7. enable_slave_receive()   |                      |
+       |------------------------->   | 8. Enable slave RX   |
        |         (IPC)               |--------------------->|
-       | 11. Message data            |                      |
+       |                             |                      |
+       | 9. enable_slave_notification()|                    |
+       |------------------------->   | 10. Enable interrupt |
+       |         (IPC)               |--------------------->|
+       |                             |                      |
+       |                             | 11. Interrupt on RX  |
+       |                             |<---------------------|
+       | 12. Notification (kernel)   |                      |
+       |<----------------------------|                      |
+       | 13. get_slave_message()     |                      |
+       |------------------------->   | 14. Read FIFO        |
+       |         (IPC)               |--------------------->|
+       | 15. Message data            |                      |
        |<-------------------------|  |                      |
 ----
 

--- a/drv/ast1060-uart/src/main.rs
+++ b/drv/ast1060-uart/src/main.rs
@@ -73,13 +73,13 @@ fn main() -> ! {
                             if rx_buf.push_back(byte).is_err() {
                                 overflow = true;
                             }
-                            if rx_buf.len() > buffer_len {
-                                if let Some((task, notification_bit)) =
-                                    notify_rx_data
-                                {
-                                    // Notify the task that data is available.
-                                    sys_post(task, 1 << notification_bit);
-                                }
+                        }
+                        if rx_buf.len() > buffer_len {
+                            if let Some((task, notification_bit)) =
+                                notify_rx_data
+                            {
+                                // Notify the task that data is available.
+                                sys_post(task, 1 << notification_bit);
                             }
                         }
                     }

--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -118,11 +118,11 @@
 //! # fn handle_mctp_message(source: u8, data: &[u8]) -> Result<(), ResponseCode> { Ok(()) }
 //! ```
 //!
-//! ## MCTP Slave Configuration (Legacy Polling - Deprecated)
+//! ## MCTP Slave Configuration (Interrupt-Driven)
 //!
 //! ```rust,no_run
 //! use drv_i2c_api::*;
-//! use userlib::TaskId;
+//! use userlib::*;
 //!
 //! # fn example(i2c_task: TaskId) -> Result<(), ResponseCode> {
 //! // Create device handle for MCTP endpoint
@@ -138,18 +138,29 @@
 //! mctp_device.configure_slave_address(0x1D)?;
 //! mctp_device.enable_slave_receive()?;
 //!
-//! // Poll for incoming messages (inefficient, deprecated)
+//! // Enable interrupt-driven notifications (use build-generated constant)
+//! // In app.toml: notifications = ["i2c-rx"]
+//! // Generates: notifications::I2C_RX_MASK
+//! mctp_device.enable_slave_notification(notifications::I2C_RX_BIT)?;
+//!
+//! // Event loop with interrupt-driven receive
+//! let mut msg_buf = [0u8; 256];
 //! loop {
-//!     match mctp_device.get_slave_message() {
-//!         Ok(message) => {
-//!             // Process MCTP message from message.source_address
-//!             handle_mctp_message(message.source_address, message.data())?;
-//!         }
-//!         Err(ResponseCode::NoSlaveMessage) => {
-//!             // No message, continue polling
-//!         }
-//!         Err(e) => {
-//!             // Handle error
+//!     let msg = sys_recv_open(&mut msg_buf, notifications::I2C_RX_MASK);
+//!     
+//!     if msg.sender == TaskId::KERNEL && (msg.operation & notifications::I2C_RX_MASK) != 0 {
+//!         // Notification: message arrived via hardware interrupt
+//!         match mctp_device.get_slave_message() {
+//!             Ok(slave_msg) => {
+//!                 // Process MCTP message from slave_msg.source_address
+//!                 handle_mctp_message(slave_msg.source_address, slave_msg.data())?;
+//!             }
+//!             Err(ResponseCode::NoSlaveMessage) => {
+//!                 // Spurious notification, continue
+//!             }
+//!             Err(e) => {
+//!                 // Handle error
+//!             }
 //!         }
 //!     }
 //! }

--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -35,11 +35,13 @@
 //!
 //! ## Slave Mode Operations (MCTP Support)
 //!
-//! New operations that allow this device to respond to incoming I2C transactions:
+//! **Interrupt-Driven Receive** (Recommended):
 //!
 //! - [`I2cDevice::configure_slave_address`] - Set up slave address
 //! - [`I2cDevice::enable_slave_receive`] - Start listening for incoming messages
-//! - [`I2cDevice::check_slave_buffer`] - Poll for received messages
+//! - [`I2cDevice::enable_slave_notification`] - Enable interrupt notifications
+//! - [`I2cDevice::get_slave_message`] - Retrieve message on notification
+//! - [`I2cDevice::disable_slave_notification`] - Stop notifications
 //! - [`I2cDevice::disable_slave_receive`] - Stop slave mode
 //!
 //! # Examples
@@ -66,7 +68,57 @@
 //! # }
 //! ```
 //!
-//! ## MCTP Slave Configuration
+//! ## MCTP Slave Configuration (Interrupt-Driven)
+//!
+//! ```rust,no_run
+//! use drv_i2c_api::*;
+//! use userlib::*;
+//!
+//! # fn example(i2c_task: TaskId) -> Result<(), ResponseCode> {
+//! // Create device handle for MCTP endpoint
+//! let mctp_device = I2cDevice::new(
+//!     i2c_task,
+//!     Controller::I2C1,
+//!     PortIndex(0),
+//!     None,
+//!     0x1D,  // Our MCTP address
+//! );
+//!
+//! // Configure as slave to receive MCTP messages
+//! mctp_device.configure_slave_address(0x1D)?;
+//! mctp_device.enable_slave_receive()?;
+//!
+//! // Enable interrupt-driven notifications (bit 0x0001)
+//! const I2C_RX_NOTIF: u32 = 0x0001;
+//! mctp_device.enable_slave_notification(I2C_RX_NOTIF)?;
+//!
+//! // Event loop with interrupt-driven receive
+//! let mut msg_buf = [0u8; 256];
+//! loop {
+//!     let msg = sys_recv_open(&mut msg_buf, I2C_RX_NOTIF);
+//!     
+//!     if msg.sender == TaskId::KERNEL && (msg.operation & I2C_RX_NOTIF) != 0 {
+//!         // Notification: message arrived
+//!         match mctp_device.get_slave_message() {
+//!             Ok(slave_msg) => {
+//!                 // Process MCTP message from slave_msg.source_address
+//!                 handle_mctp_message(slave_msg.source_address, slave_msg.data())?;
+//!             }
+//!             Err(ResponseCode::NoSlaveMessage) => {
+//!                 // Spurious notification, continue
+//!             }
+//!             Err(e) => {
+//!                 // Handle error
+//!             }
+//!         }
+//!     }
+//! }
+//! # Ok(())
+//! # }
+//! # fn handle_mctp_message(source: u8, data: &[u8]) -> Result<(), ResponseCode> { Ok(()) }
+//! ```
+//!
+//! ## MCTP Slave Configuration (Legacy Polling - Deprecated)
 //!
 //! ```rust,no_run
 //! use drv_i2c_api::*;
@@ -86,15 +138,20 @@
 //! mctp_device.configure_slave_address(0x1D)?;
 //! mctp_device.enable_slave_receive()?;
 //!
-//! // Poll for incoming messages
-//! let mut messages = [SlaveMessage::default(); 4];
-//! let msg_count = mctp_device.get_slave_messages(&mut messages)?;
-//!
-//! for i in 0..msg_count {
-//!     let message = &messages[i];
-//!     // Process MCTP message from message.source_address
-//!     // Message data is available via message.data()
-//!     handle_mctp_message(message.source_address, message.data())?;
+//! // Poll for incoming messages (inefficient, deprecated)
+//! loop {
+//!     match mctp_device.get_slave_message() {
+//!         Ok(message) => {
+//!             // Process MCTP message from message.source_address
+//!             handle_mctp_message(message.source_address, message.data())?;
+//!         }
+//!         Err(ResponseCode::NoSlaveMessage) => {
+//!             // No message, continue polling
+//!         }
+//!         Err(e) => {
+//!             // Handle error
+//!         }
+//!     }
 //! }
 //! # Ok(())
 //! # }
@@ -714,6 +771,9 @@ impl I2cDevice {
     /// After this operation, the controller will begin buffering incoming 
     /// messages sent to its configured slave address(es).
     ///
+    /// For efficient interrupt-driven operation, call [`enable_slave_notification`]
+    /// after this to receive notifications when messages arrive.
+    ///
     /// This must be called after [`configure_slave_address`] to begin receiving
     /// slave messages.
     ///
@@ -737,9 +797,95 @@ impl I2cDevice {
     }
 
     ///
+    /// Enable interrupt-driven notifications for slave message reception.
+    /// When messages arrive at the configured slave address, the I2C driver
+    /// will send a notification to the calling task with the specified notification
+    /// mask.
+    ///
+    /// This enables efficient, interrupt-driven receive processing instead of
+    /// polling, which is critical for protocols like MCTP that require low
+    /// latency and power efficiency.
+    ///
+    /// ## Arguments
+    ///
+    /// * `notification_mask` - The notification bit(s) to set when a message arrives
+    ///
+    /// ## Requirements
+    ///
+    /// - The calling task must have the I2C driver in its task-slots
+    /// - The notification bit must be configured in the task's notifications array
+    /// - `enable_slave_receive` must have been called first
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// use drv_i2c_api::*;
+    /// # fn example(device: I2cDevice) -> Result<(), ResponseCode> {
+    /// // Configure slave mode
+    /// device.configure_slave_address(0x1D)?;
+    /// device.enable_slave_receive()?;
+    /// 
+    /// // Enable notifications (bit 0 in notification mask)
+    /// device.enable_slave_notification(0x0001)?;
+    ///
+    /// // In your event loop:
+    /// // if notification_received & 0x0001 {
+    /// //     let msg = device.get_slave_message()?;
+    /// //     process_message(msg);
+    /// // }
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    pub fn enable_slave_notification(&self, notification_mask: u32) -> Result<(), ResponseCode> {
+        let mut response = 0_usize;
+
+        let (code, _) = sys_send(
+            self.task,
+            Op::EnableSlaveNotification as u16,
+            &Marshal::marshal(&(
+                0, // Unused for slave operations
+                self.controller,
+                self.port,
+                self.segment,
+            )),
+            response.as_mut_bytes(),
+            &[Lease::from(notification_mask.as_bytes())],
+        );
+
+        self.response_code(code, ())
+    }
+
+    ///
+    /// Disable interrupt-driven notifications for slave message reception.
+    /// After this operation, the driver will stop sending notifications when
+    /// messages arrive. Messages will still be buffered and can be retrieved
+    /// via polling with [`get_slave_message`].
+    ///
+    pub fn disable_slave_notification(&self) -> Result<(), ResponseCode> {
+        let mut response = 0_usize;
+
+        let (code, _) = sys_send(
+            self.task,
+            Op::DisableSlaveNotification as u16,
+            &Marshal::marshal(&(
+                0, // Unused for slave operations
+                self.controller,
+                self.port,
+                self.segment,
+            )),
+            response.as_mut_bytes(),
+            &[],
+        );
+
+        self.response_code(code, ())
+    }
+
+    ///
     /// Disable slave receive mode for this controller/port. After this
     /// operation, the controller will stop responding to slave transactions
-    /// and will not buffer incoming messages.
+    /// and will not buffer incoming messages. Notifications will also be
+    /// automatically disabled.
     ///
     pub fn disable_slave_receive(&self) -> Result<(), ResponseCode> {
         let mut response = 0_usize;
@@ -761,34 +907,59 @@ impl I2cDevice {
     }
 
     ///
-    /// Check for received slave messages and retrieve them from the internal
-    /// buffer. Returns the number of messages retrieved.
-    ///
-    /// ## Arguments
-    ///
-    /// * `buffer` - Buffer to receive the slave messages. Each message is
-    ///              formatted as: [source_addr, length, data...]
+    /// Retrieve a single slave message from the hardware receive buffer.
+    /// This operation should be called in response to a slave receive 
+    /// notification, or can be used for polling if notifications are disabled.
     ///
     /// ## Returns
     ///
-    /// The number of bytes written to the buffer, representing one or more
-    /// complete messages. Returns 0 if no messages are available.
+    /// A [`SlaveMessage`] containing the source address and message data, or
+    /// [`ResponseCode::NoSlaveMessage`] if no messages are available.
     ///
-    /// ## Message Format
+    /// ## Usage with Notifications
     ///
-    /// Each message in the buffer is formatted as:
-    /// - `[0]`: Source address (7-bit address of the master that sent this)
-    /// - `[1]`: Message length (N)
-    /// - `[2..N+1]`: Message data
+    /// ```rust,no_run
+    /// use drv_i2c_api::*;
+    /// use userlib::*;
+    /// 
+    /// # fn example(device: I2cDevice, notification_mask: u32) -> Result<(), ResponseCode> {
+    /// // Setup
+    /// device.configure_slave_address(0x1D)?;
+    /// device.enable_slave_receive()?;
+    /// device.enable_slave_notification(notification_mask)?;
     ///
-    /// Multiple messages may be returned in a single buffer if space permits.
+    /// // Event loop
+    /// loop {
+    ///     let msg = sys_recv_open(&mut buffer, notification_mask);
+    ///     
+    ///     if msg.sender == TaskId::KERNEL && (msg.operation & notification_mask) != 0 {
+    ///         // Notification received - retrieve the message
+    ///         match device.get_slave_message() {
+    ///             Ok(slave_msg) => {
+    ///                 // Process message from slave_msg.source_address
+    ///                 process(slave_msg.data());
+    ///             }
+    ///             Err(ResponseCode::NoSlaveMessage) => {
+    ///                 // Spurious notification or already processed
+    ///             }
+    ///             Err(e) => {
+    ///                 // Handle error
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    /// # Ok(())
+    /// # }
+    /// # fn process(data: &[u8]) {}
+    /// ```
     ///
-    pub fn check_slave_buffer(&self, buffer: &mut [u8]) -> Result<usize, ResponseCode> {
+    pub fn get_slave_message(&self) -> Result<SlaveMessage, ResponseCode> {
+        let mut buffer = [0u8; 257]; // 1 byte source + 1 byte len + 255 max data
         let mut response = 0_usize;
 
         let (code, _) = sys_send(
             self.task,
-            Op::CheckSlaveBuffer as u16,
+            Op::GetSlaveMessage as u16,
             &Marshal::marshal(&(
                 0, // Unused for slave operations
                 self.controller,
@@ -796,57 +967,34 @@ impl I2cDevice {
                 self.segment,
             )),
             response.as_mut_bytes(),
-            &[Lease::from(buffer)],
+            &[Lease::from(&mut buffer[..])],
         );
 
-        self.response_code(code, response)
+        self.response_code(code, ())?;
+
+        if response == 0 {
+            return Err(ResponseCode::NoSlaveMessage);
+        }
+
+        // Parse the message: [source_addr, length, data...]
+        if response < 2 {
+            return Err(ResponseCode::BadArg);
+        }
+
+        let source_addr = buffer[0];
+        let data_length = buffer[1] as usize;
+
+        if response < 2 + data_length {
+            return Err(ResponseCode::BadArg);
+        }
+
+        SlaveMessage::new(source_addr, &buffer[2..2 + data_length])
+            .map_err(|_| ResponseCode::BadArg)
     }
 
-    ///
-    /// Convenience method to retrieve slave messages as structured data.
-    /// This parses the raw buffer from [`check_slave_buffer`] into individual
-    /// [`SlaveMessage`] objects.
-    ///
-    /// ## Arguments
-    ///
-    /// * `messages` - Slice to store the parsed messages
-    ///
-    /// ## Returns
-    ///
-    /// The number of messages parsed and stored in the slice.
-    ///
-    pub fn get_slave_messages(&self, messages: &mut [SlaveMessage]) -> Result<usize, ResponseCode> {
-        let mut buffer = [0u8; 1024]; // Buffer for raw message data
-        let bytes_read = self.check_slave_buffer(&mut buffer)?;
-        
-        let mut message_count = 0;
-        let mut pos = 0;
-        
-        while pos < bytes_read && message_count < messages.len() {
-            if pos + 2 > bytes_read {
-                break; // Not enough data for header
-            }
-            
-            let source_addr = buffer[pos];
-            let data_length = buffer[pos + 1];
-            pos += 2;
-            
-            if pos + data_length as usize > bytes_read {
-                break; // Not enough data for payload
-            }
-            
-            let message_data = &buffer[pos..pos + data_length as usize];
-            
-            match SlaveMessage::new(source_addr, message_data) {
-                Ok(message) => {
-                    messages[message_count] = message;
-                    message_count += 1;
-                    pos += data_length as usize;
-                }
-                Err(_) => break, // Invalid message format
-            }
-        }
-        
-        Ok(message_count)
-    }
+    // ================================================================
+    // DEPRECATED: Polling-based slave receive
+    // ================================================================
+
+
 }

--- a/drv/i2c-api/src/lib.rs
+++ b/drv/i2c-api/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! # Extended Capabilities
 //!
-//! This crate provides both traditional master operations and new slave mode 
+//! This crate provides both traditional master operations and new slave mode
 //! operations for peer-to-peer protocols like MCTP:
 //!
 //! ## Master Mode Operations
@@ -741,7 +741,7 @@ impl I2cDevice {
     // ================================================================
 
     ///
-    /// Configure this I2C controller/port to act as a slave device with the 
+    /// Configure this I2C controller/port to act as a slave device with the
     /// specified address. This enables the controller to respond to incoming
     /// I2C transactions from other masters on the bus.
     ///
@@ -758,9 +758,12 @@ impl I2cDevice {
     /// Returns [`ResponseCode::SlaveAddressInUse`] if the address is already configured.
     /// Returns [`ResponseCode::SlaveNotSupported`] if slave mode is not supported on this controller.
     ///
-    pub fn configure_slave_address(&self, slave_address: u8) -> Result<(), ResponseCode> {
+    pub fn configure_slave_address(
+        &self,
+        slave_address: u8,
+    ) -> Result<(), ResponseCode> {
         let mut response = 0_usize;
-        
+
         let (code, _) = sys_send(
             self.task,
             Op::ConfigureSlaveAddress as u16,
@@ -779,7 +782,7 @@ impl I2cDevice {
 
     ///
     /// Enable slave receive mode for this controller/port combination.
-    /// After this operation, the controller will begin buffering incoming 
+    /// After this operation, the controller will begin buffering incoming
     /// messages sent to its configured slave address(es).
     ///
     /// For efficient interrupt-driven operation, call [`enable_slave_notification`]
@@ -835,7 +838,7 @@ impl I2cDevice {
     /// // Configure slave mode
     /// device.configure_slave_address(0x1D)?;
     /// device.enable_slave_receive()?;
-    /// 
+    ///
     /// // Enable notifications (bit 0 in notification mask)
     /// device.enable_slave_notification(0x0001)?;
     ///
@@ -848,7 +851,10 @@ impl I2cDevice {
     /// # }
     /// ```
     ///
-    pub fn enable_slave_notification(&self, notification_mask: u32) -> Result<(), ResponseCode> {
+    pub fn enable_slave_notification(
+        &self,
+        notification_mask: u32,
+    ) -> Result<(), ResponseCode> {
         let mut response = 0_usize;
 
         let (code, _) = sys_send(
@@ -919,7 +925,7 @@ impl I2cDevice {
 
     ///
     /// Retrieve a single slave message from the hardware receive buffer.
-    /// This operation should be called in response to a slave receive 
+    /// This operation should be called in response to a slave receive
     /// notification, or can be used for polling if notifications are disabled.
     ///
     /// ## Returns
@@ -932,7 +938,7 @@ impl I2cDevice {
     /// ```rust,no_run
     /// use drv_i2c_api::*;
     /// use userlib::*;
-    /// 
+    ///
     /// # fn example(device: I2cDevice, notification_mask: u32) -> Result<(), ResponseCode> {
     /// // Setup
     /// device.configure_slave_address(0x1D)?;
@@ -1006,6 +1012,4 @@ impl I2cDevice {
     // ================================================================
     // DEPRECATED: Polling-based slave receive
     // ================================================================
-
-
 }

--- a/drv/i2c-types/src/lib.rs
+++ b/drv/i2c-types/src/lib.rs
@@ -29,14 +29,14 @@
 //! - **Fixed Buffer Size**: Messages use a fixed 255-byte buffer to match typical
 //!   I2C transaction limits and simplify memory management without dynamic allocation.
 //!
-//! - **Serialization Requirements**: Types used in IPC messages must implement 
-//!   `SerializedSize`, `Serialize`, and `Deserialize` for Hubris IPC communication. 
-//!   Newtypes like `PortIndex` inherit these requirements when used in serializable 
+//! - **Serialization Requirements**: Types used in IPC messages must implement
+//!   `SerializedSize`, `Serialize`, and `Deserialize` for Hubris IPC communication.
+//!   Newtypes like `PortIndex` inherit these requirements when used in serializable
 //!   contexts (e.g., as fields in `SlaveConfig`).
 //!
-//! - **Large Array Serialization**: Arrays larger than 32 elements require the 
-//!   `serde-big-array` crate and `#[serde(with = "BigArray")]` attribute. This 
-//!   follows the established Hubris pattern used in `host-sp-messages` and other 
+//! - **Large Array Serialization**: Arrays larger than 32 elements require the
+//!   `serde-big-array` crate and `#[serde(with = "BigArray")]` attribute. This
+//!   follows the established Hubris pattern used in `host-sp-messages` and other
 //!   crates for handling buffers that exceed serde's built-in array size limits.
 //!
 //! ### Usage Pattern
@@ -84,7 +84,7 @@ pub enum Op {
     WriteReadBlock = 2,
 
     /// Configure the I2C controller to act as a slave device with the specified
-    /// address. This enables the controller to respond to incoming I2C 
+    /// address. This enables the controller to respond to incoming I2C
     /// transactions from other masters on the bus.
     ///
     /// The payload should contain:
@@ -98,7 +98,7 @@ pub enum Op {
     ConfigureSlaveAddress = 3,
 
     /// Enable slave receive mode for the specified controller/port combination.
-    /// After this operation, the controller will begin buffering incoming 
+    /// After this operation, the controller will begin buffering incoming
     /// messages sent to its configured slave address(es).
     ///
     /// When used with `EnableSlaveNotification`, the controller will send
@@ -154,7 +154,7 @@ pub enum Op {
     DisableSlaveNotification = 7,
 
     /// Retrieve a single slave message from the hardware receive buffer.
-    /// This operation should be called in response to a slave receive 
+    /// This operation should be called in response to a slave receive
     /// notification, or can be used for polling if notifications are disabled.
     ///
     /// The payload should contain:
@@ -328,7 +328,17 @@ pub enum ReservedAddress {
 /// letter/number convention should be used (e.g., "B1") -- but this is purely
 /// convention.
 ///
-#[derive(Copy, Clone, Debug, FromPrimitive, Eq, PartialEq, SerializedSize, Serialize, Deserialize)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    FromPrimitive,
+    Eq,
+    PartialEq,
+    SerializedSize,
+    Serialize,
+    Deserialize,
+)]
 pub struct PortIndex(pub u8);
 
 ///
@@ -391,11 +401,13 @@ pub enum Segment {
 }
 
 /// Represents a message received while operating in I2C slave mode
-/// 
+///
 /// When the I2C controller is configured as a slave, it can receive messages
 /// from other masters on the bus. Each received message includes the source
 /// address and the data payload.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, SerializedSize)]
+#[derive(
+    Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, SerializedSize,
+)]
 pub struct SlaveMessage {
     /// The 7-bit I2C address of the master that sent this message
     pub source_address: u8,
@@ -413,17 +425,17 @@ impl SlaveMessage {
         if data.len() > 255 {
             return Err(ResponseCode::TooMuchData);
         }
-        
+
         let mut msg = SlaveMessage {
             source_address,
             data_length: data.len() as u8,
             data: [0; 255],
         };
-        
+
         msg.data[..data.len()].copy_from_slice(data);
         Ok(msg)
     }
-    
+
     /// Get the valid data portion of this message
     pub fn data(&self) -> &[u8] {
         &self.data[..self.data_length as usize]
@@ -441,7 +453,9 @@ impl Default for SlaveMessage {
 }
 
 /// Configuration for I2C slave mode operation
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, SerializedSize)]
+#[derive(
+    Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, SerializedSize,
+)]
 pub struct SlaveConfig {
     /// The controller to configure for slave operation
     pub controller: Controller,
@@ -453,17 +467,21 @@ pub struct SlaveConfig {
 
 impl SlaveConfig {
     /// Create a new slave configuration
-    pub fn new(controller: Controller, port: PortIndex, address: u8) -> Result<Self, ResponseCode> {
+    pub fn new(
+        controller: Controller,
+        port: PortIndex,
+        address: u8,
+    ) -> Result<Self, ResponseCode> {
         // Validate that the address is not reserved
         if ReservedAddress::from_u8(address).is_some() {
             return Err(ResponseCode::BadSlaveAddress);
         }
-        
+
         // Ensure it's a valid 7-bit address
         if address > 0x7F {
             return Err(ResponseCode::BadSlaveAddress);
         }
-        
+
         Ok(SlaveConfig {
             controller,
             port,

--- a/drv/i2c-types/src/lib.rs
+++ b/drv/i2c-types/src/lib.rs
@@ -101,6 +101,9 @@ pub enum Op {
     /// After this operation, the controller will begin buffering incoming 
     /// messages sent to its configured slave address(es).
     ///
+    /// When used with `EnableSlaveNotification`, the controller will send
+    /// notifications when messages arrive instead of requiring polling.
+    ///
     /// This must be called after `ConfigureSlaveAddress` to begin receiving
     /// slave messages.
     EnableSlaveReceive = 4,
@@ -110,18 +113,70 @@ pub enum Op {
     /// and will not buffer incoming messages.
     DisableSlaveReceive = 5,
 
-    /// Check for received slave messages and retrieve them from the internal
-    /// buffer. Returns the number of messages retrieved and their data.
+    /// Enable interrupt-driven notifications for slave message reception.
+    /// When messages arrive at the configured slave address, the I2C driver
+    /// will send a notification to the specified task with the given notification
+    /// bit.
     ///
-    /// The caller should provide a sufficient buffer to receive multiple
-    /// messages. Each message is formatted as:
+    /// This enables efficient, interrupt-driven receive processing instead of
+    /// polling, which is critical for protocols like MCTP that require low
+    /// latency and power efficiency.
+    ///
+    /// The payload should contain:
+    /// - `[0]`: Controller index
+    /// - `[1]`: Port index
+    /// - `[2]`: Reserved (0)
+    /// - `[3]`: Reserved (0)
+    /// - Lease 0: Notification mask (u32) to use when signaling the client
+    ///
+    /// Must be called after `EnableSlaveReceive` to receive interrupt-driven
+    /// notifications. The client task must be configured to receive notifications
+    /// from the I2C driver in its app.toml task-slots configuration.
+    ///
+    /// ## Example Configuration
+    ///
+    /// ```toml
+    /// [tasks.mctp_server]
+    /// task-slots = ["i2c_driver"]
+    /// notifications = ["i2c-slave-rx", "timer"]
+    /// ```
+    ///
+    /// The I2C driver will post the notification when:
+    /// - A complete message has been received to the slave address
+    /// - The hardware receive buffer is ready to be read
+    /// - An error occurs during slave reception
+    EnableSlaveNotification = 6,
+
+    /// Disable interrupt-driven notifications for slave message reception.
+    /// After this operation, the driver will stop sending notifications when
+    /// messages arrive, and the client must use `GetSlaveMessage` polling
+    /// or re-enable notifications.
+    DisableSlaveNotification = 7,
+
+    /// Retrieve a single slave message from the hardware receive buffer.
+    /// This operation should be called in response to a slave receive 
+    /// notification, or can be used for polling if notifications are disabled.
+    ///
+    /// The payload should contain:
+    /// - `[0]`: Reserved (0)
+    /// - `[1]`: Controller index
+    /// - `[2]`: Port index
+    /// - `[3]`: Reserved (0)
+    /// - Lease 0: Buffer to receive message data
+    ///
+    /// Returns the number of bytes written to the buffer, representing one
+    /// complete message. Returns 0 if no messages are available.
+    ///
+    /// ## Message Format (in lease buffer)
+    ///
     /// - `[0]`: Source address (7-bit address of the master that sent this)
-    /// - `[1]`: Message length
-    /// - `[2..N]`: Message data
+    /// - `[1]`: Message length (N)
+    /// - `[2..N+1]`: Message data
     ///
-    /// Returns the total number of bytes written to the buffer, or 0 if no
-    /// messages are available.
-    CheckSlaveBuffer = 6,
+    /// Unlike the old `CheckSlaveBuffer`, this returns a single message per
+    /// call to maintain compatibility with interrupt-driven processing where
+    /// each notification typically corresponds to one message.
+    GetSlaveMessage = 8,
 }
 
 /// The response code returned from the I2C server.  These response codes pretty
@@ -207,6 +262,10 @@ pub enum ResponseCode {
     BadSlaveAddress,
     /// Slave mode configuration failed due to hardware limitations
     SlaveConfigurationFailed,
+    /// No slave message available
+    NoSlaveMessage,
+    /// Notification registration failed
+    NotificationFailed,
 }
 
 ///
@@ -368,6 +427,16 @@ impl SlaveMessage {
     /// Get the valid data portion of this message
     pub fn data(&self) -> &[u8] {
         &self.data[..self.data_length as usize]
+    }
+}
+
+impl Default for SlaveMessage {
+    fn default() -> Self {
+        Self {
+            source_address: 0,
+            data_length: 0,
+            data: [0; 255],
+        }
     }
 }
 

--- a/drv/i2c-types/src/traits.rs
+++ b/drv/i2c-types/src/traits.rs
@@ -15,20 +15,20 @@ pub enum I2cSpeed {
 }
 
 /// Hardware abstraction trait for I2C controllers
-/// 
+///
 /// This trait provides a platform-agnostic interface for I2C hardware operations,
 /// enabling the I2C server to work across different microcontroller families
 /// while maintaining the same high-level business logic.
-/// 
+///
 /// # Design Principles
-/// 
+///
 /// - **Hardware Agnostic**: Works across STM32, LPC55, RISC-V, and other platforms
 /// - **Error Transparent**: Uses existing ResponseCode taxonomy for consistency  
 /// - **Operation Atomic**: Each method represents a complete I2C transaction
 /// - **Resource Safe**: Handles controller enable/disable and bus recovery
-/// 
+///
 /// # Implementation Notes
-/// 
+///
 /// Platform-specific implementations should handle:
 /// - Register programming for the target microcontroller
 /// - Interrupt management and timing
@@ -40,31 +40,31 @@ pub trait I2cHardware {
     type Error: Into<ResponseCode>;
 
     /// Perform a write followed by read operation on the I2C bus
-    /// 
+    ///
     /// This is the fundamental I2C operation supporting both simple reads/writes
     /// and complex register-based device interactions.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `controller` - Which I2C controller to use (I2C0, I2C1, etc.)
     /// * `addr` - 7-bit I2C device address
     /// * `write_data` - Data to write to the device (empty slice for read-only)
     /// * `read_buffer` - Buffer to fill with read data (empty slice for write-only)
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// Number of bytes successfully read, or hardware-specific error
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust,ignore
     /// // Read register 0x42 from device at address 0x50
     /// let mut value = [0u8; 2];
     /// let count = hw.write_read(Controller::I2C0, 0x50, &[0x42], &mut value)?;
-    /// 
+    ///
     /// // Write-only operation
     /// hw.write_read(Controller::I2C0, 0x50, &[0x10, 0xFF], &mut [])?;
-    /// 
+    ///
     /// // Read-only operation  
     /// let mut data = [0u8; 4];
     /// hw.write_read(Controller::I2C0, 0x50, &[], &mut data)?;
@@ -78,20 +78,20 @@ pub trait I2cHardware {
     ) -> Result<usize, Self::Error>;
 
     /// Perform an SMBus block read operation
-    /// 
+    ///
     /// In SMBus block read, the device returns a byte count followed by that
     /// many data bytes. This is commonly used for reading variable-length
     /// data from smart devices.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `controller` - Which I2C controller to use  
     /// * `addr` - 7-bit I2C device address
     /// * `write_data` - Command/register to write before reading
     /// * `read_buffer` - Buffer to fill with block data (without length byte)
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// Number of actual data bytes read (excluding the length byte)
     fn write_read_block(
         &mut self,
@@ -102,12 +102,12 @@ pub trait I2cHardware {
     ) -> Result<usize, Self::Error>;
 
     /// Configure I2C bus timing for the specified speed
-    /// 
+    ///
     /// This configures the I2C controller's clock dividers and timing parameters
     /// to achieve the target bus frequency.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `controller` - Which I2C controller to configure
     /// * `speed` - Target bus speed (Standard, Fast, FastPlus, HighSpeed)
     fn configure_timing(
@@ -117,75 +117,81 @@ pub trait I2cHardware {
     ) -> Result<(), Self::Error>;
 
     /// Reset and recover a locked I2C bus
-    /// 
+    ///
     /// When I2C transactions fail or devices misbehave, the bus can become
     /// locked with SDA held low. This method attempts recovery by:
     /// - Switching pins to GPIO mode
     /// - Generating clock pulses to complete any partial transactions
     /// - Sending a STOP condition
     /// - Restoring I2C alternate function mode
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `controller` - Which I2C controller/bus to reset
     fn reset_bus(&mut self, controller: Controller) -> Result<(), Self::Error>;
 
     /// Enable I2C controller hardware and configure pins
-    /// 
+    ///
     /// This method handles platform-specific initialization:
     /// - Enable peripheral clocks  
     /// - Configure GPIO pins for I2C alternate function
     /// - Initialize I2C controller registers
     /// - Enable interrupts if using interrupt-driven mode
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `controller` - Which I2C controller to enable
-    fn enable_controller(&mut self, controller: Controller) -> Result<(), Self::Error>;
+    fn enable_controller(
+        &mut self,
+        controller: Controller,
+    ) -> Result<(), Self::Error>;
 
     /// Disable I2C controller and return pins to GPIO mode
-    /// 
+    ///
     /// This provides clean shutdown and power savings:
     /// - Disable I2C controller
     /// - Return GPIO pins to input/floating state  
     /// - Disable peripheral clocks
     /// - Clear any pending interrupts
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `controller` - Which I2C controller to disable
-    fn disable_controller(&mut self, controller: Controller) -> Result<(), Self::Error>;
+    fn disable_controller(
+        &mut self,
+        controller: Controller,
+    ) -> Result<(), Self::Error>;
 
     // =========================================================================
     // Slave Mode Operations for MCTP and Peer-to-Peer Protocols
     // =========================================================================
 
     /// Configure I2C controller to operate as a slave device
-    /// 
+    ///
     /// This enables the controller to respond to incoming I2C transactions from
     /// other masters on the bus. Essential for MCTP-over-I2C implementations
     /// where devices need bidirectional communication.
-    /// 
+    ///
     /// # Hardware Implementation Requirements
-    /// 
+    ///
     /// - Program slave address registers (primary and optionally secondary)
     /// - Enable slave mode interrupts or polling mechanism
     /// - Configure receive buffers for incoming data
     /// - Set up address matching (7-bit, general call, etc.)
     /// - Enable slave acknowledge generation
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `controller` - Which I2C controller to configure
     /// * `config` - Slave configuration (address, port, etc.)
-    /// 
+    ///
     /// # MCTP Considerations
-    /// 
+    ///
     /// For MCTP-over-I2C, the slave address typically represents the device's
     /// Endpoint ID (EID) in the MCTP network topology.
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```rust,ignore
     /// // Configure as MCTP endpoint with EID 0x1D
     /// let config = SlaveConfig::new(Controller::I2C0, PortIndex::new(0), 0x1D)?;
@@ -198,79 +204,85 @@ pub trait I2cHardware {
     ) -> Result<(), Self::Error>;
 
     /// Enable slave receive mode to start listening for incoming messages
-    /// 
+    ///
     /// After configuring the slave address, this method activates the hardware
     /// to begin receiving and buffering incoming I2C transactions addressed to
     /// this device.
-    /// 
+    ///
     /// # Hardware Implementation Requirements
-    /// 
+    ///
     /// - Enable slave mode operation in controller registers
     /// - Start address matching logic
     /// - Enable interrupts for slave events (address match, data receive, stop)
     /// - Initialize receive buffers and state machines
     /// - Configure clock stretching if supported
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `controller` - Which I2C controller to enable
-    fn enable_slave_receive(&mut self, controller: Controller) -> Result<(), Self::Error>;
+    fn enable_slave_receive(
+        &mut self,
+        controller: Controller,
+    ) -> Result<(), Self::Error>;
 
     /// Disable slave receive mode
-    /// 
+    ///
     /// Stops the controller from responding to incoming slave transactions.
     /// This is useful for power management or when switching communication modes.
-    /// 
+    ///
     /// # Hardware Implementation Requirements
-    /// 
+    ///
     /// - Disable slave mode operation
     /// - Stop address matching
     /// - Disable slave interrupts
     /// - Clear any pending slave state
     /// - Optionally flush receive buffers
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `controller` - Which I2C controller to disable
-    fn disable_slave_receive(&mut self, controller: Controller) -> Result<(), Self::Error>;
+    fn disable_slave_receive(
+        &mut self,
+        controller: Controller,
+    ) -> Result<(), Self::Error>;
 
     /// Check for received slave messages and retrieve them
-    /// 
+    ///
     /// This method polls the hardware for any messages received while operating
     /// in slave mode. For MCTP implementations, this is typically called
     /// periodically to process incoming protocol messages.
-    /// 
+    ///
     /// # Hardware Implementation Requirements
-    /// 
+    ///
     /// - Check slave receive buffers for completed transactions
     /// - Extract source address from transaction (if available)
     /// - Copy received data to message buffers
     /// - Handle message fragmentation for large MCTP packets
     /// - Clear hardware flags for processed messages
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `controller` - Which I2C controller to check
     /// * `messages` - Buffer to fill with received messages
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// Number of messages retrieved, or hardware error
-    /// 
+    ///
     /// # MCTP Protocol Notes
-    /// 
+    ///
     /// MCTP-over-I2C messages may span multiple I2C transactions. The hardware
     /// implementation should:
     /// - Buffer partial messages until complete
     /// - Handle MCTP packet headers and routing
     /// - Provide source address for response routing
-    /// 
+    ///
     /// # Example
-    /// 
+    ///
     /// ```rust,ignore
     /// let mut messages = [SlaveMessage::default(); 8];
     /// let count = hw.poll_slave_messages(Controller::I2C0, &mut messages)?;
-    /// 
+    ///
     /// for i in 0..count {
     ///     let msg = &messages[i];
     ///     // Process MCTP message from msg.source_address
@@ -284,27 +296,30 @@ pub trait I2cHardware {
     ) -> Result<usize, Self::Error>;
 
     /// Get slave mode status and statistics
-    /// 
+    ///
     /// Returns information about the current slave mode operation, including
     /// error conditions, buffer status, and performance metrics.
-    /// 
+    ///
     /// # Hardware Implementation
-    /// 
+    ///
     /// Should report:
     /// - Whether slave mode is currently enabled
     /// - Number of messages received/dropped
     /// - Buffer overflow conditions
     /// - Address match statistics
     /// - Bus error conditions specific to slave mode
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `controller` - Which I2C controller to query
-    fn get_slave_status(&self, controller: Controller) -> Result<SlaveStatus, Self::Error>;
+    fn get_slave_status(
+        &self,
+        controller: Controller,
+    ) -> Result<SlaveStatus, Self::Error>;
 }
 
 /// Status information for I2C slave mode operation
-/// 
+///
 /// Provides visibility into slave mode health and performance for debugging
 /// and monitoring MCTP protocol implementations.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/drv/openprot-i2c-server/src/main.rs
+++ b/drv/openprot-i2c-server/src/main.rs
@@ -1,14 +1,19 @@
 //! Mock I2C Server - Embedded Binary
 //!
 //! This is the embedded binary entry point for the mock I2C server driver.
+//! 
+//! This implementation uses manual IPC handling (like the UART driver) to support
+//! timer notifications for injecting test slave messages asynchronously.
 
 #![no_std]
 #![no_main]
 
 use drv_i2c_api::*;
-use drv_i2c_types::{traits::I2cHardware, Op, ResponseCode};
+use drv_i2c_types::{traits::I2cHardware, Op, ResponseCode, SlaveMessage};
 
-use userlib::{hl, LeaseAttributes};
+use userlib::{LeaseAttributes, sys_recv_open, sys_reply, sys_borrow_info, 
+              sys_borrow_read, sys_borrow_write, sys_post, set_timer_relative, 
+              TaskId, RecvMessage, FromPrimitive};
 use ringbuf::*;
 
 mod mock_driver;
@@ -26,152 +31,417 @@ enum Trace {
 
 counted_ringbuf!(Trace, 64, Trace::None);
 
+// Timer configuration for injecting test slave messages
+const TIMER_INTERVAL_MS: u32 = 100;  // Generate test message every 100ms
+// Notification bit must match app.toml: notifications = ["i2c-irq", "timer"]
+// Position 1 (timer) → bit 1 (0x0002)
+const TIMER_NOTIF: u32 = 0x0002;      // Timer notification bit
+
 #[export_name = "main"]
 fn main() -> ! {
     // Create Mock I2C driver on the stack for IPC testing
     let mut driver = MockI2cDriver::new();
     
-    // Optional: Configure driver for specific test scenarios
-    // Example: driver.set_device_response(Controller::I2C0, 0x50, &[0x12, 0x34]).ok();
+    // State for notification-driven slave message injection
+    let mut notification_client: Option<(TaskId, u32)> = None;
+    let mut timer_armed: bool = false;
 
-    // Field messages
-    let mut buffer = [0; 4];
+    // Message buffer for IPC
+    let mut buffer = [0u8; 4];
 
     loop {
-        hl::recv_without_notification(&mut buffer, |op, msg| match op {
-            Op::WriteRead | Op::WriteReadBlock => {
-                let lease_count = msg.lease_count();
-
-                let (payload, caller) = msg
-                    .fixed::<[u8; 4], usize>()
-                    .ok_or(ResponseCode::BadArg)?;
-
-                if lease_count < 2 || lease_count % 2 != 0 {
-                    return Err(ResponseCode::BadArg);
+        let msginfo = sys_recv_open(&mut buffer, TIMER_NOTIF);
+        
+        // Handle timer notification - inject slave message
+        if msginfo.sender == TaskId::KERNEL {
+            if msginfo.operation & TIMER_NOTIF != 0 {
+                if let Some((client_task, notif_mask)) = notification_client {
+                    // Inject a test slave message
+                    if driver.inject_slave_message().is_ok() {
+                        // Notify the client that a message is available
+                        sys_post(client_task, notif_mask);
+                    }
+                    
+                    // Re-arm timer for next message if still enabled
+                    if timer_armed {
+                        set_timer_relative(TIMER_INTERVAL_MS, TIMER_NOTIF);
+                    }
                 }
-
-                // For mock mode, we use the standard marshal format but ignore complex topology
-                let (addr, controller, _port, _mux) = Marshal::unmarshal(payload)?;
-
-                let mut total = 0;
-
-                // Iterate over write/read pairs
-                for i in (0..lease_count).step_by(2) {
-                    let wbuf = caller.borrow(i);
-                    let winfo = wbuf.info().ok_or(ResponseCode::BadArg)?;
-
-                    if !winfo.attributes.contains(LeaseAttributes::READ) {
-                        return Err(ResponseCode::BadArg);
-                    }
-
-                    let rbuf = caller.borrow(i + 1);
-                    let rinfo = rbuf.info().ok_or(ResponseCode::BadArg)?;
-
-                    if winfo.len == 0 && rinfo.len == 0 {
-                        return Err(ResponseCode::BadArg);
-                    }
-
-                    if winfo.len > 255 || rinfo.len > 255 {
-                        // Keep the 255 limit as per IPC protocol
-                        return Err(ResponseCode::BadArg);
-                    }
-
-                    // Read write data from lease
-                    let mut write_data = [0u8; 255];
-                    for pos in 0..winfo.len {
-                        write_data[pos] = wbuf.read_at(pos).ok_or(ResponseCode::BadArg)?;
-                    }
-
-                    // Prepare read buffer
-                    let mut read_buffer = [0u8; 255];
-                    let read_slice = &mut read_buffer[..rinfo.len];
-
-                    // Perform the I2C transaction
-                    let bytes_read = if op == Op::WriteReadBlock {
-                        driver.write_read_block(
-                            controller,
-                            addr,
-                            &write_data[..winfo.len],
-                            read_slice,
-                        )?
-                    } else {
-                        driver.write_read(
-                            controller,
-                            addr,
-                            &write_data[..winfo.len],
-                            read_slice,
-                        )?
-                    };
-
-                    // Write read data back to lease
-                    for pos in 0..bytes_read.min(rinfo.len) {
-                        rbuf.write_at(pos, read_slice[pos]).ok_or(ResponseCode::BadArg)?;
-                    }
-
-                    total += bytes_read;
-                }
-
-                caller.reply(total);
-                Ok(())
             }
-            Op::ConfigureSlaveAddress => {
-                // Use the same marshal format as WriteRead operations
-                let (payload, caller) = msg
-                    .fixed::<[u8; 4], usize>()
-                    .ok_or(ResponseCode::BadArg)?;
-
-                let (slave_address, controller, port, _segment) = Marshal::unmarshal(payload)?;
-                
-                // Create slave configuration  
-                let config = SlaveConfig::new(controller, port, slave_address)
-                    .map_err(|_| ResponseCode::BadArg)?;
-                
-                // Configure slave mode on hardware
-                driver.configure_slave_mode(controller, &config)?;
-                
-                caller.reply(0usize);
-                Ok(())
+            continue;
+        }
+        
+        // Decode operation
+        let op = match Op::from_u32(msginfo.operation) {
+            Some(op) => op,
+            None => {
+                sys_reply(msginfo.sender, 1, &[]); // Bad operation
+                continue;
             }
-            Op::EnableSlaveReceive => {
-                // Use the same marshal format as WriteRead operations
-                let (payload, caller) = msg
-                    .fixed::<[u8; 4], usize>()
-                    .ok_or(ResponseCode::BadArg)?;
-
-                let (_address, controller, _port, _segment) = Marshal::unmarshal(payload)?;
-                
-                driver.enable_slave_receive(controller)?;
-                caller.reply(0usize);
-                Ok(())
-            }
-            Op::DisableSlaveReceive => {
-                // Use the same marshal format as WriteRead operations
-                let (payload, caller) = msg
-                    .fixed::<[u8; 4], usize>()
-                    .ok_or(ResponseCode::BadArg)?;
-
-                let (_address, controller, _port, _segment) = Marshal::unmarshal(payload)?;
-                
-                driver.disable_slave_receive(controller)?;
-                caller.reply(0usize);
-                Ok(())
-            }
-            Op::CheckSlaveBuffer => {
-                // Use the same marshal format as WriteRead operations
-                let (payload, caller) = msg
-                    .fixed::<[u8; 4], usize>()
-                    .ok_or(ResponseCode::BadArg)?;
-
-                let (_address, controller, _port, _segment) = Marshal::unmarshal(payload)?;
-                
-                // Check for slave messages - for now just return count
-                // A full implementation would need to handle message data formatting
-                let temp_messages: [u8; 0] = []; // Empty for mock
-                let count = temp_messages.len();
-                
-                caller.reply(count);
-                Ok(())
-            }
-        });
+        };
+        
+        // Handle IPC operation
+        handle_operation(op, &msginfo, &mut buffer, &mut driver, &mut notification_client, &mut timer_armed);
     }
 }
+
+fn handle_operation(
+    op: Op,
+    msginfo: &RecvMessage,
+    buffer: &mut [u8],
+    driver: &mut MockI2cDriver,
+    notification_client: &mut Option<(TaskId, u32)>,
+    timer_armed: &mut bool,
+) {
+    match op {
+        Op::WriteRead | Op::WriteReadBlock => {
+            handle_write_read(op, msginfo, buffer, driver);
+        }
+        Op::ConfigureSlaveAddress => {
+            handle_configure_slave_address(msginfo, buffer, driver);
+        }
+        Op::EnableSlaveReceive => {
+            handle_enable_slave_receive(msginfo, buffer, driver);
+        }
+        Op::DisableSlaveReceive => {
+            handle_disable_slave_receive(msginfo, buffer, driver);
+        }
+        Op::EnableSlaveNotification => {
+            handle_enable_slave_notification(msginfo, buffer, notification_client, timer_armed);
+        }
+        Op::DisableSlaveNotification => {
+            handle_disable_slave_notification(msginfo, notification_client, timer_armed);
+        }
+        Op::GetSlaveMessage => {
+            handle_get_slave_message(msginfo, buffer, driver);
+        }
+    }
+}
+
+fn handle_write_read(
+    op: Op,
+    msginfo: &RecvMessage,
+    buffer: &[u8],
+    driver: &mut MockI2cDriver,
+) {
+    let lease_count = msginfo.lease_count;
+    
+    if lease_count < 2 || lease_count % 2 != 0 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    // Extract marshal payload from buffer
+    if msginfo.message_len < 4 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    let payload: [u8; 4] = [buffer[0], buffer[1], buffer[2], buffer[3]];
+    let (addr, controller, _port, _mux) = match Marshal::unmarshal(&payload) {
+        Ok(vals) => vals,
+        Err(e) => {
+            sys_reply(msginfo.sender, e as u32, &[]);
+            return;
+        }
+    };
+    
+    let mut total = 0;
+    
+    // Iterate over write/read pairs
+    for i in (0..lease_count).step_by(2) {
+        // Get write buffer info
+        let winfo = match sys_borrow_info(msginfo.sender, i) {
+            Some(info) => info,
+            None => {
+                sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+                return;
+            }
+        };
+        
+        if !winfo.attributes.contains(LeaseAttributes::READ) {
+            sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+            return;
+        }
+        
+        // Get read buffer info
+        let rinfo = match sys_borrow_info(msginfo.sender, i + 1) {
+            Some(info) => info,
+            None => {
+                sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+                return;
+            }
+        };
+        
+        if winfo.len == 0 && rinfo.len == 0 {
+            sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+            return;
+        }
+        
+        if winfo.len > 255 || rinfo.len > 255 {
+            sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+            return;
+        }
+        
+        // Read write data from lease
+        let mut write_data = [0u8; 255];
+        for pos in 0..winfo.len {
+            let (rc, _) = sys_borrow_read(msginfo.sender, i, pos, &mut write_data[pos..pos+1]);
+            if rc != 0 {
+                sys_reply(msginfo.sender, rc, &[]);
+                return;
+            }
+        }
+        
+        // Prepare read buffer
+        let mut read_buffer = [0u8; 255];
+        let read_slice = &mut read_buffer[..rinfo.len];
+        
+        // Perform the I2C transaction
+        let bytes_read = if op == Op::WriteReadBlock {
+            match driver.write_read_block(controller, addr, &write_data[..winfo.len], read_slice) {
+                Ok(n) => n,
+                Err(e) => {
+                    sys_reply(msginfo.sender, e as u32, &[]);
+                    return;
+                }
+            }
+        } else {
+            match driver.write_read(controller, addr, &write_data[..winfo.len], read_slice) {
+                Ok(n) => n,
+                Err(e) => {
+                    sys_reply(msginfo.sender, e as u32, &[]);
+                    return;
+                }
+            }
+        };
+        
+        // Write read data back to lease
+        for pos in 0..bytes_read.min(rinfo.len) {
+            let (rc, _) = sys_borrow_write(msginfo.sender, i + 1, pos, &read_slice[pos..pos+1]);
+            if rc != 0 {
+                sys_reply(msginfo.sender, rc, &[]);
+                return;
+            }
+        }
+        
+        total += bytes_read;
+    }
+    
+    sys_reply(msginfo.sender, 0, &total.to_le_bytes());
+}
+
+fn handle_configure_slave_address(
+    msginfo: &RecvMessage,
+    buffer: &[u8],
+    driver: &mut MockI2cDriver,
+) {
+    if msginfo.message_len < 4 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    let payload: [u8; 4] = [buffer[0], buffer[1], buffer[2], buffer[3]];
+    let (slave_address, controller, port, _segment) = match Marshal::unmarshal(&payload) {
+        Ok(vals) => vals,
+        Err(e) => {
+            sys_reply(msginfo.sender, e as u32, &[]);
+            return;
+        }
+    };
+    
+    use drv_i2c_types::SlaveConfig;
+    let config = match SlaveConfig::new(controller, port, slave_address) {
+        Ok(c) => c,
+        Err(_) => {
+            sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+            return;
+        }
+    };
+    
+    match driver.configure_slave_mode(controller, &config) {
+        Ok(()) => sys_reply(msginfo.sender, 0, &[]),
+        Err(e) => sys_reply(msginfo.sender, e as u32, &[]),
+    }
+}
+
+fn handle_enable_slave_receive(
+    msginfo: &RecvMessage,
+    buffer: &[u8],
+    driver: &mut MockI2cDriver,
+) {
+    if msginfo.message_len < 4 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    let payload: [u8; 4] = [buffer[0], buffer[1], buffer[2], buffer[3]];
+    let (_address, controller, _port, _segment) = match Marshal::unmarshal(&payload) {
+        Ok(vals) => vals,
+        Err(e) => {
+            sys_reply(msginfo.sender, e as u32, &[]);
+            return;
+        }
+    };
+    
+    match driver.enable_slave_receive(controller) {
+        Ok(()) => sys_reply(msginfo.sender, 0, &[]),
+        Err(e) => sys_reply(msginfo.sender, e as u32, &[]),
+    }
+}
+
+fn handle_disable_slave_receive(
+    msginfo: &RecvMessage,
+    buffer: &[u8],
+    driver: &mut MockI2cDriver,
+) {
+    if msginfo.message_len < 4 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    let payload: [u8; 4] = [buffer[0], buffer[1], buffer[2], buffer[3]];
+    let (_address, controller, _port, _segment) = match Marshal::unmarshal(&payload) {
+        Ok(vals) => vals,
+        Err(e) => {
+            sys_reply(msginfo.sender, e as u32, &[]);
+            return;
+        }
+    };
+    
+    match driver.disable_slave_receive(controller) {
+        Ok(()) => sys_reply(msginfo.sender, 0, &[]),
+        Err(e) => sys_reply(msginfo.sender, e as u32, &[]),
+    }
+}
+
+fn handle_enable_slave_notification(
+    msginfo: &RecvMessage,
+    buffer: &[u8],
+    notification_client: &mut Option<(TaskId, u32)>,
+    timer_armed: &mut bool,
+) {
+    if msginfo.message_len < 4 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    // Check for lease with notification mask
+    if msginfo.lease_count < 1 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    let lease_info = match sys_borrow_info(msginfo.sender, 0) {
+        Some(info) => info,
+        None => {
+            sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+            return;
+        }
+    };
+    
+    if lease_info.len < 4 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    // Read notification mask from lease (u32, 4 bytes)
+    let mut mask_bytes = [0u8; 4];
+    for i in 0..4 {
+        let (rc, _) = sys_borrow_read(msginfo.sender, 0, i, &mut mask_bytes[i..i+1]);
+        if rc != 0 {
+            sys_reply(msginfo.sender, rc, &[]);
+            return;
+        }
+    }
+    let notif_mask = u32::from_le_bytes(mask_bytes);
+    
+    // Store client info and start timer
+    *notification_client = Some((msginfo.sender, notif_mask));
+    *timer_armed = true;
+    set_timer_relative(TIMER_INTERVAL_MS, TIMER_NOTIF);
+    
+    sys_reply(msginfo.sender, 0, &[]);
+}
+
+fn handle_disable_slave_notification(
+    msginfo: &RecvMessage,
+    notification_client: &mut Option<(TaskId, u32)>,
+    timer_armed: &mut bool,
+) {
+    // Clear notification state and stop timer
+    *notification_client = None;
+    *timer_armed = false;
+    
+    // Cancel any pending timer
+    use userlib::sys_set_timer;
+    sys_set_timer(None, TIMER_NOTIF);
+    
+    sys_reply(msginfo.sender, 0, &[]);
+}
+
+fn handle_get_slave_message(
+    msginfo: &RecvMessage,
+    buffer: &[u8],
+    driver: &mut MockI2cDriver,
+) {
+    if msginfo.message_len < 4 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    let payload: [u8; 4] = [buffer[0], buffer[1], buffer[2], buffer[3]];
+    let (_address, controller, _port, _segment) = match Marshal::unmarshal(&payload) {
+        Ok(vals) => vals,
+        Err(e) => {
+            sys_reply(msginfo.sender, e as u32, &[]);
+            return;
+        }
+    };
+    
+    // Check that we have a lease for returning the message
+    if msginfo.lease_count < 1 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    // Try to get a message from the driver
+    let mut messages = [SlaveMessage::default(); 1];
+    match driver.poll_slave_messages(controller, &mut messages) {
+        Ok(1) => {
+            // Message available - write to lease
+            let slave_msg = &messages[0];
+            
+            // Write: source_address (1 byte) + data_length (1 byte) + data
+            let mut write_buf = [0u8; 257]; // max: 2 + 255
+            write_buf[0] = slave_msg.source_address;
+            write_buf[1] = slave_msg.data_length;
+            write_buf[2..2 + slave_msg.data_length as usize]
+                .copy_from_slice(&slave_msg.data[..slave_msg.data_length as usize]);
+            
+            let total_len = 2 + slave_msg.data_length as usize;
+            for i in 0..total_len {
+                let (rc, _) = sys_borrow_write(msginfo.sender, 0, i, &write_buf[i..i+1]);
+                if rc != 0 {
+                    sys_reply(msginfo.sender, rc, &[]);
+                    return;
+                }
+            }
+            
+            sys_reply(msginfo.sender, 0, &total_len.to_le_bytes());
+        }
+        Ok(0) => {
+            // No message available
+            sys_reply(msginfo.sender, ResponseCode::NoSlaveMessage as u32, &[]);
+        }
+        Ok(_) => {
+            // Unexpected count
+            sys_reply(msginfo.sender, ResponseCode::BadResponse as u32, &[]);
+        }
+        Err(e) => {
+            sys_reply(msginfo.sender, e as u32, &[]);
+        }
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/notifications.rs"));

--- a/lib/ast1060-uart-log/Cargo.toml
+++ b/lib/ast1060-uart-log/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ast1060-uart-log"
+version = "0.1.0"
+edition = "2021"
+description = "Print log messages over the AST1060 UART"
+
+[dependencies]
+critical-section.workspace = true
+embedded-io.workspace = true
+log.workspace = true
+ast1060-uart-api = { path = "../../drv/ast1060-uart-api" }
+
+[lib]
+test = false
+doctest = false
+bench = false
+
+[lints]
+workspace = true

--- a/lib/ast1060-uart-log/src/lib.rs
+++ b/lib/ast1060-uart-log/src/lib.rs
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_main]
+#![no_std]
+
+use ast1060_uart_api::Uart;
+use core::cell::{OnceCell, RefCell};
+use critical_section::Mutex;
+use embedded_io::Write;
+use log::{Level, Metadata, Record};
+
+static LOGGER: IoWriteLogger = IoWriteLogger::new();
+struct IoWriteLogger {
+    writer: Mutex<RefCell<Option<Uart>>>,
+    level: Mutex<OnceCell<Level>>,
+}
+impl IoWriteLogger {
+    const fn new() -> Self {
+        IoWriteLogger {
+            writer: Mutex::new(RefCell::new(None)),
+            level: Mutex::new(OnceCell::new()),
+        }
+    }
+}
+
+impl log::Log for IoWriteLogger {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        critical_section::with(|cs| {
+            metadata.level()
+                <= self.level.borrow(cs).get().cloned().unwrap_or(Level::Info)
+        })
+    }
+    fn log(&self, record: &Record<'_>) {
+        if self.enabled(record.metadata()) {
+            critical_section::with(|cs| {
+                if let Some(uart) = self.writer.borrow(cs).borrow_mut().as_mut()
+                {
+                    uart.write_fmt(format_args!(
+                        "[{}] - {}: {}\n",
+                        record.level(),
+                        record.target(),
+                        record.args()
+                    ))
+                    .ok();
+                }
+            });
+        }
+    }
+    fn flush(&self) {
+        critical_section::with(|cs| {
+            if let Some(uart) = self.writer.borrow(cs).borrow_mut().as_mut() {
+                let _ = uart.flush();
+            }
+        });
+    }
+}
+
+pub fn init(uart: Uart, level: log::Level) -> Result<(), log::SetLoggerError> {
+    critical_section::with(|cs| {
+        LOGGER.writer.borrow(cs).replace(Some(uart));
+        LOGGER.level.borrow(cs).set(level).ok();
+    });
+    log::set_logger(&LOGGER)
+        .map(|()| log::set_max_level(log::LevelFilter::Info))
+}

--- a/task/mctp-server/Cargo.toml
+++ b/task/mctp-server/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ast1060-pac = { workspace = true, features = ["rt"] }
 cortex-m = { workspace = true }
 cortex-m-rt = { workspace = true }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
@@ -18,14 +17,22 @@ zerocopy-derive = { workspace = true }
 mctp-api = { path = "../mctp-api" }
 mctp-stack = { git = "https://github.com/9elements/mctp-lib.git", branch = "buildup", package = "mctp-lib" }
 mctp = { workspace = true }
-lib-ast1060-uart = { path = "../../lib/ast1060-uart" }
+ast1060-uart-api = { path = "../../drv/ast1060-uart-api", optional = true }
 nb = {workspace = true}
 heapless = { workspace = true }
 embedded-io = { workspace = true }
+drv-i2c-api = { path = "../../drv/i2c-api", optional = true }
+ast1060-uart-log = { path = "../../lib/ast1060-uart-log", optional = true }
+log.workspace = true
 
 [build-dependencies]
 idol = { workspace = true }
 build-util = { path = "../../build/util" }
+
+[features]
+transport_serial = ["dep:ast1060-uart-api"]
+transport_i2c = ["dep:drv-i2c-api"]
+serial_log = ["dep:ast1060-uart-api", "dep:ast1060-uart-log"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/mctp-server/src/i2c.rs
+++ b/task/mctp-server/src/i2c.rs
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use super::I2C_MAX_EIDS;
+use drv_i2c_api::*;
+use heapless::FnvIndexMap;
+use log::{trace, warn};
+use mctp::{Eid, Result};
+use mctp_stack::i2c::{MctpI2cEncap, MCTP_I2C_MAXMTU};
+use userlib::TaskId;
+
+pub struct I2cSender {
+    i2c_driver_task: TaskId,
+    _neighbor_table: FnvIndexMap<Eid, u8, { I2C_MAX_EIDS as usize }>,
+}
+impl I2cSender {
+    pub fn new(i2c_driver_task: TaskId) -> Self {
+        Self {
+            i2c_driver_task,
+            _neighbor_table: FnvIndexMap::new(),
+        }
+    }
+}
+impl mctp_stack::Sender for I2cSender {
+    fn send_vectored(
+        &mut self,
+        mut fragmenter: mctp_stack::fragment::Fragmenter,
+        payload: &[&[u8]],
+    ) -> Result<mctp::Tag> {
+        // TODO The stack needs to provide the destination EID to the sender
+        // let addr = self
+        //     .neighbor_table
+        //     .get(eid)
+        //     .ok_or(mctp::Error::Unreachable)?;
+        let addr = 0x42;
+        let i2c = I2cDevice::new(
+            self.i2c_driver_task,
+            Controller::I2C1,
+            PortIndex(0),
+            None,
+            addr,
+        );
+        let encoder = MctpI2cEncap::new(super::I2C_OWN_ADDR);
+        loop {
+            let mut pkt = [0u8; mctp_stack::serial::MTU_MAX];
+            let r = fragmenter.fragment_vectored(payload, &mut pkt);
+
+            match r {
+                mctp_stack::fragment::SendOutput::Packet(p) => {
+                    let mut out = [0; MCTP_I2C_MAXMTU + 8]; // max MTU + I2C header size
+                    let packet = encoder.encode(addr, &p, &mut out, true)?;
+                    trace!("I2C MCTP TX: {:02x?}", &packet);
+                    i2c.write(&out).map_err(|e| {
+                        warn!("I2C MCTP TX error: {:?}", e);
+                        mctp::Error::TxFailure
+                    })?;
+                }
+                mctp_stack::fragment::SendOutput::Complete { tag, .. } => {
+                    trace!("I2C MCTP TX Complete");
+                    break Ok(tag);
+                }
+                mctp_stack::fragment::SendOutput::Error { err, .. } => {
+                    warn!("I2C MCTP TX fragmenter error: {:?}", err);
+                    break Err(err);
+                }
+            }
+        }
+    }
+
+    fn get_mtu(&self) -> usize {
+        MCTP_I2C_MAXMTU
+    }
+}

--- a/task/mctp-server/src/main.rs
+++ b/task/mctp-server/src/main.rs
@@ -77,17 +77,23 @@ fn main() -> ! {
 
     // Setup MCTP server over I2C transport if enabled
     #[cfg(feature = "transport_i2c")]
-    let _i2c_recv = I2cDevice::new(
-        I2C.get_task_id(),
-        Controller::I2C1,
-        PortIndex(0),
-        None,
-        0x00, // Addr not used for slave mode
-    );
-    #[cfg(feature = "transport_i2c")]
-    let mut server: Server<_, MAX_OUTSTANDING> = {
+    let (i2c_recv, mut server, mut i2c_reader) = {
+        let i2c_recv = I2cDevice::new(
+            I2C.get_task_id(),
+            Controller::I2C1,
+            PortIndex(0),
+            None,
+            0x00, // Address unused for slave mode; configured via configure_slave_address()
+        );
+        i2c_recv.configure_slave_address(I2C_OWN_ADDR).unwrap_lite();
+        i2c_recv.enable_slave_receive().unwrap_lite();
+        i2c_recv.enable_slave_notification(notifications::I2C_RX_BIT).unwrap_lite();
+        
         let i2c_sender = i2c::I2cSender::new(I2C.get_task_id());
-        Server::new(mctp::Eid(INITIAL_EID), 0, i2c_sender)
+        let server = Server::new(mctp::Eid(INITIAL_EID), 0, i2c_sender);
+        let i2c_reader = mctp_stack::i2c::MctpI2cHandler::new();
+        
+        (i2c_recv, server, i2c_reader)
     };
 
     let state = sys_get_timer();
@@ -99,23 +105,28 @@ fn main() -> ! {
     let notification_mask =
         notifications::RX_DATA_MASK | notifications::TIMER_MASK;
     #[cfg(feature = "transport_i2c")]
-    let notification_mask = notifications::TIMER_MASK;
+    let notification_mask = notifications::I2C_RX_MASK | notifications::TIMER_MASK;
     loop {
         let msg = sys_recv_open(&mut msg_buf, notification_mask);
 
-        #[cfg(feature = "transport_serial")]
-        handle_serial_transport(&msg, &mut server, &usart, &mut serial_reader);
+        if msg.sender == TaskId::KERNEL {
+            // Handle kernel notifications
+            #[cfg(feature = "transport_serial")]
+            if (msg.operation & notifications::RX_DATA_MASK) != 0 {
+                handle_serial_transport(&msg, &mut server, &usart, &mut serial_reader);
+            }
 
-        if msg.sender == TaskId::KERNEL
-            && (msg.operation & notifications::TIMER_MASK) != 0
-        {
-            // TODO: Multiplex timer to recv I2C packets (or implemnt interrupt-driven I2C)
-            let state = sys_get_timer();
-            server.update(state.now);
-            continue;
-        }
+            #[cfg(feature = "transport_i2c")]
+            if (msg.operation & notifications::I2C_RX_MASK) != 0 {
+                handle_i2c_transport(&msg, &mut server, &i2c_recv, &mut i2c_reader);
+            }
 
-        if msg.sender != TaskId::KERNEL {
+            if (msg.operation & notifications::TIMER_MASK) != 0 {
+                let state = sys_get_timer();
+                server.update(state.now);
+            }
+        } else {
+            // Handle IPC messages from other tasks
             handle_mctp_msg(&msg_buf, msg, &mut server);
         }
     }
@@ -123,22 +134,55 @@ fn main() -> ! {
 
 #[cfg(feature = "transport_serial")]
 fn handle_serial_transport<S: mctp_stack::Sender, const OUTSTANDING: usize>(
-    msg: &RecvMessage,
+    _msg: &RecvMessage,
     server: &mut server::Server<S, OUTSTANDING>,
     uart: &RefCell<Uart>,
     serial_reader: &mut mctp_stack::serial::MctpSerialHandler,
 ) {
-    if msg.sender == TaskId::KERNEL
-        && (msg.operation & notifications::RX_DATA_MASK) != 0
-    {
-        let usart = &mut uart.borrow_mut();
-        let pkt = serial_reader.recv(&mut usart.deref_mut());
-        match server.stack.inbound(pkt.unwrap_lite()) {
-            Ok(_) => {}
-            Err(_) => return,
-        };
-        let state = sys_get_timer();
-        server.update(state.now);
+    let usart = &mut uart.borrow_mut();
+    let pkt = serial_reader.recv(&mut usart.deref_mut());
+    match server.stack.inbound(pkt.unwrap_lite()) {
+        Ok(_) => {}
+        Err(_) => return,
+    };
+    let state = sys_get_timer();
+    server.update(state.now);
+}
+
+#[cfg(feature = "transport_i2c")]
+fn handle_i2c_transport<S: mctp_stack::Sender, const OUTSTANDING: usize>(
+    _msg: &RecvMessage,
+    server: &mut server::Server<S, OUTSTANDING>,
+    i2c_device: &I2cDevice,
+    i2c_reader: &mut mctp_stack::i2c::MctpI2cHandler,
+) {
+    match i2c_device.get_slave_message() {
+        Ok(slave_msg) => {
+            let data = slave_msg.data();
+            log::trace!("I2C MCTP RX: {:02x?}", data);
+            match i2c_reader.recv(data) {
+                Ok(pkt) => {
+                    match server.stack.inbound(pkt) {
+                        Ok(_) => {
+                            let state = sys_get_timer();
+                            server.update(state.now);
+                        }
+                        Err(e) => {
+                            log::warn!("MCTP stack inbound error: {:?}", e);
+                        }
+                    }
+                }
+                Err(e) => {
+                    log::warn!("I2C MCTP decode error: {:?}", e);
+                }
+            }
+        }
+        Err(ResponseCode::NoSlaveMessage) => {
+            // Spurious notification, ignore
+        }
+        Err(e) => {
+            log::warn!("I2C slave message error: {:?}", e);
+        }
     }
 }
 

--- a/task/mctp-server/src/main.rs
+++ b/task/mctp-server/src/main.rs
@@ -87,12 +87,14 @@ fn main() -> ! {
         );
         i2c_recv.configure_slave_address(I2C_OWN_ADDR).unwrap_lite();
         i2c_recv.enable_slave_receive().unwrap_lite();
-        i2c_recv.enable_slave_notification(notifications::I2C_RX_BIT).unwrap_lite();
-        
+        i2c_recv
+            .enable_slave_notification(notifications::I2C_RX_BIT)
+            .unwrap_lite();
+
         let i2c_sender = i2c::I2cSender::new(I2C.get_task_id());
         let server = Server::new(mctp::Eid(INITIAL_EID), 0, i2c_sender);
         let i2c_reader = mctp_stack::i2c::MctpI2cHandler::new();
-        
+
         (i2c_recv, server, i2c_reader)
     };
 
@@ -105,7 +107,8 @@ fn main() -> ! {
     let notification_mask =
         notifications::RX_DATA_MASK | notifications::TIMER_MASK;
     #[cfg(feature = "transport_i2c")]
-    let notification_mask = notifications::I2C_RX_MASK | notifications::TIMER_MASK;
+    let notification_mask =
+        notifications::I2C_RX_MASK | notifications::TIMER_MASK;
     loop {
         let msg = sys_recv_open(&mut msg_buf, notification_mask);
 
@@ -113,12 +116,22 @@ fn main() -> ! {
             // Handle kernel notifications
             #[cfg(feature = "transport_serial")]
             if (msg.operation & notifications::RX_DATA_MASK) != 0 {
-                handle_serial_transport(&msg, &mut server, &usart, &mut serial_reader);
+                handle_serial_transport(
+                    &msg,
+                    &mut server,
+                    &usart,
+                    &mut serial_reader,
+                );
             }
 
             #[cfg(feature = "transport_i2c")]
             if (msg.operation & notifications::I2C_RX_MASK) != 0 {
-                handle_i2c_transport(&msg, &mut server, &i2c_recv, &mut i2c_reader);
+                handle_i2c_transport(
+                    &msg,
+                    &mut server,
+                    &i2c_recv,
+                    &mut i2c_reader,
+                );
             }
 
             if (msg.operation & notifications::TIMER_MASK) != 0 {
@@ -161,17 +174,15 @@ fn handle_i2c_transport<S: mctp_stack::Sender, const OUTSTANDING: usize>(
             let data = slave_msg.data();
             log::trace!("I2C MCTP RX: {:02x?}", data);
             match i2c_reader.recv(data) {
-                Ok(pkt) => {
-                    match server.stack.inbound(pkt) {
-                        Ok(_) => {
-                            let state = sys_get_timer();
-                            server.update(state.now);
-                        }
-                        Err(e) => {
-                            log::warn!("MCTP stack inbound error: {:?}", e);
-                        }
+                Ok(pkt) => match server.stack.inbound(pkt) {
+                    Ok(_) => {
+                        let state = sys_get_timer();
+                        server.update(state.now);
                     }
-                }
+                    Err(e) => {
+                        log::warn!("MCTP stack inbound error: {:?}", e);
+                    }
+                },
                 Err(e) => {
                     log::warn!("I2C MCTP decode error: {:?}", e);
                 }

--- a/task/mctp-server/src/server.rs
+++ b/task/mctp-server/src/server.rs
@@ -133,9 +133,6 @@ impl<S: mctp_stack::Sender, const OUTSTANDING: usize> Server<S, OUTSTANDING> {
         ic: bool,
         buf: Leased<R, [u8]>,
     ) {
-        // TODO figure out if handling incoming packets while sending is neccessary.
-        //      Having dedicated driver tasks with buffering for every transport would simplify this.
-
         let mut msg_buf = [0; MAX_PAYLOAD];
         if msg_buf.len() < buf.len() {
             sys_reply(msg.sender, ServerError::NoSpace.into(), &[]);


### PR DESCRIPTION
- Fixes a bug in the UART driver task
- Adds a crate that implements a AST1060 UART logger for the `log` crate
- Use UART driver API in MCTP server
- Add draft implementation for MCTP I2C transport binding
- Add feature gates for different MCTP transport bindings and UART logging 