### PR TITLE
drv/openprot-i2c-server: Update mock driver for new slave operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ast1060-mctp-i2c-echo"
+version = "0.1.0"
+dependencies = [
+ "ast1060-pac",
+ "cortex-m",
+ "cortex-m-rt",
+ "kern",
+]
+
+[[package]]
 name = "ast1060-pac"
 version = "0.1.0"
 source = "git+https://github.com/aspeedtech-bmc/ast1060-pac.git#35ce8190e9b40deff918300b69d23079ca15a3f4"
@@ -4137,17 +4147,19 @@ dependencies = [
 name = "mctp-server"
 version = "0.1.0"
 dependencies = [
- "ast1060-pac",
+ "ast1060-uart-api",
+ "ast1060-uart-log",
  "build-util",
  "cortex-m",
  "cortex-m-rt",
  "counters",
+ "drv-i2c-api",
  "embedded-io",
  "heapless 0.7.17",
  "hubpack",
  "idol",
  "idol-runtime",
- "lib-ast1060-uart",
+ "log",
  "mctp 0.2.0 (git+https://github.com/OpenPRoT/mctp-rs.git?branch=sync-features)",
  "mctp-api",
  "mctp-lib",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ast1060-uart-log"
+version = "0.1.0"
+dependencies = [
+ "ast1060-uart-api",
+ "critical-section",
+ "embedded-io",
+ "log",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ indexmap = { version = "1.4.0", default-features = false, features = ["serde-1"]
 indoc = { version = "2.0.3", default-features = false }
 itertools = { version = "0.10.5", default-features = false }
 leb128 = { version = "0.2.5", default-features = false }
+log = "0.4"
 lpc55-pac = { version = "0.4", default-features = false }
 memchr = { version = "2.4", default-features = false }
 memoffset = { version = "0.6.5", default-features = false }

--- a/app/ast1060-i2c-scaffold/app.toml
+++ b/app/ast1060-i2c-scaffold/app.toml
@@ -30,7 +30,7 @@ max-sizes = {flash = 16384, ram = 4096}
 start = true
 features = ["mock-only"]
 stacksize = 2048
-notifications = ["i2c-irq"]
+notifications = ["i2c-irq", "timer"]
 
 [tasks.i2c_client]
 name = "task-i2c-client"

--- a/app/ast1060-mctp-i2c-echo/Cargo.toml
+++ b/app/ast1060-mctp-i2c-echo/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+edition = "2021"
+readme = "README.md"
+name = "ast1060-mctp-i2c-echo"
+version = "0.1.0"
+
+[features]
+#dump = ["kern/dump"]
+jtag-halt = []
+
+[dependencies]
+ast1060-pac = { workspace = true, features = ["rt"] }
+cortex-m = { workspace = true }
+cortex-m-rt = { workspace = true }
+kern = { path = "../../sys/kern" }
+
+# this lets you use `cargo fix`!
+[[bin]]
+name = "ast1060-mctp-i2c-echo"
+test = false
+doctest = false
+bench = false
+
+[lints]
+workspace = true

--- a/app/ast1060-mctp-i2c-echo/README.md
+++ b/app/ast1060-mctp-i2c-echo/README.md
@@ -1,0 +1,11 @@
+# AST1060 mctp over i2c echo example
+
+A MCTP demo/test application that runs on the Aspeed AST1030/AST1060.
+
+An echo task listens for incoming MCTP reqests with message type `1` and replies by echoing the payload.
+
+EID is statically assigned to `8` by the echo task.
+
+## Testing under Linux
+
+_TODO_

--- a/app/ast1060-mctp-i2c-echo/app.toml
+++ b/app/ast1060-mctp-i2c-echo/app.toml
@@ -38,7 +38,7 @@ max-sizes = {flash = 32867, ram = 16384}
 start = true
 stacksize = 12288
 task-slots = ["uart_driver", "i2c_driver"]
-notifications = ["rx-data", "timer"]
+notifications = ["rx-data", "timer", "i2c-slave"]
 features = ["serial_log", "transport_i2c"]
 
 [tasks.uart_driver]

--- a/app/ast1060-mctp-i2c-echo/app.toml
+++ b/app/ast1060-mctp-i2c-echo/app.toml
@@ -1,11 +1,11 @@
-name = "ast1060-mctp-echo"
+name = "ast1060-mctp-i2c-echo"
 target = "thumbv7em-none-eabihf"
 board = "ast1060-rot"
 chip = "../../chips/ast1060"
 stacksize = 1024 
 
 [kernel]
-name = "ast1060-mctp-echo"
+name = "ast1060-mctp-i2c-echo"
 requires = {flash = 20000, ram = 3072}
 
 [tasks.jefe]
@@ -34,14 +34,12 @@ task-slots = ["mctp_server"]
 [tasks.mctp_server]
 name = "mctp-server"
 priority = 3
-max-sizes = {flash = 32768, ram = 16384}
+max-sizes = {flash = 32867, ram = 16384}
 start = true
 stacksize = 12288
-notifications = ["uart-irq", "timer", "rx-data"]
-interrupts = {"uart.irq" = "uart-irq"}
-uses = ["uart"]
-task-slots = ["uart_driver"]
-features = ["transport_serial"]
+task-slots = ["uart_driver", "i2c_driver"]
+notifications = ["rx-data", "timer"]
+features = ["serial_log", "transport_i2c"]
 
 [tasks.uart_driver]
 name = "drv-ast1060-uart"
@@ -51,3 +49,12 @@ uses = ["uart"]
 start = true
 notifications = ["uart-irq"]
 interrupts = {"uart.irq" = "uart-irq"}
+
+[tasks.i2c_driver]
+name = "drv-mock-i2c"
+priority = 2
+max-sizes = {flash = 16384, ram = 4096}
+start = true
+features = ["mock-only"]
+stacksize = 2048
+notifications = ["i2c-irq"]

--- a/app/ast1060-mctp-i2c-echo/src/main.rs
+++ b/app/ast1060-mctp-i2c-echo/src/main.rs
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_std]
+#![no_main]
+
+// We have to do this if we don't otherwise use it to ensure its vector table
+// gets linked in.
+
+use ast1060_pac::Peripherals;
+use cortex_m_rt::entry;
+
+#[cfg(feature = "jtag-halt")]
+use core::ptr::{self, addr_of};
+
+#[entry]
+fn main() -> ! {
+    // This code just forces the ast1060 pac to be linked in.
+    let peripherals = unsafe { Peripherals::steal() };
+    peripherals.scu.scu000().modify(|_, w| w);
+    peripherals.scu.scu41c().modify(|_, w| {
+        // Set the JTAG pinmux to 0x1f << 25
+        w.enbl_armtmsfn_pin()
+            .bit(true)
+            .enbl_armtckfn_pin()
+            .bit(true)
+            .enbl_armtrstfn_pin()
+            .bit(true)
+            .enbl_armtdifn_pin()
+            .bit(true)
+            .enbl_armtdofn_pin()
+            .bit(true)
+    });
+
+    #[cfg(feature = "jtag-halt")]
+    jtag_halt();
+
+    // Default boot speed, until we bother raising it:
+    const CYCLES_PER_MS: u32 = 16_000;
+
+    unsafe { kern::startup::start_kernel(CYCLES_PER_MS) }
+}
+
+#[cfg(feature = "jtag-halt")]
+fn jtag_halt() {
+    static mut HALT: u32 = 1;
+
+    // This is a hack to halt the CPU in JTAG mode.
+    // It writes a value to a volatile memory location
+    // Break by jtag and set val to zero to continue.
+    loop {
+        let val;
+        unsafe {
+            val = ptr::read_volatile(addr_of!(HALT));
+        }
+
+        if val == 0 {
+            break;
+        }
+    }
+}

--- a/doc/i2c-api.adoc
+++ b/doc/i2c-api.adoc
@@ -1,0 +1,864 @@
+= I2C API Design and Requirements
+:toc: left
+:toclevels: 3
+:sectnums:
+:source-highlighter: rouge
+
+== Overview
+
+The I2C API (`drv-i2c-api`) provides a client interface for I2C communication in Hubris applications. Unlike traditional I2C APIs that only support master mode operations, this implementation extends support to **slave mode** operations required for peer-to-peer protocols like MCTP (Management Component Transport Protocol).
+
+The API is designed around Hubris's task-based architecture, using IPC to communicate with separate I2C driver tasks that control the actual hardware.
+
+== Architecture
+
+=== Component Structure
+
+[source]
+----
+Application Task               I2C Driver Task           Hardware
+    (Client)                      (Server)
+       |                             |                      |
+       | 1. Create I2cDevice         |                      |
+       |    (controller, port, addr) |                      |
+       |                             |                      |
+       | 2. read_reg() / write()     |                      |
+       |------------------------->   |                      |
+       |         (IPC)               | 3. Hardware I/O      |
+       |                             |--------------------->|
+       |                             |<---------------------|
+       | 4. Reply with data          |                      |
+       |<-------------------------|  |                      |
+       |                             |                      |
+       | 5. enable_slave_receive()   |                      |
+       |------------------------->   | 6. Configure slave   |
+       |         (IPC)               |--------------------->|
+       |                             |                      |
+       |                             | 7. Interrupt on RX   |
+       |                             |<---------------------|
+       | 8. Notification (kernel)    |                      |
+       |<----------------------------|                      |
+       | 9. get_slave_message()      |                      |
+       |------------------------->   | 10. Read FIFO        |
+       |         (IPC)               |--------------------->|
+       | 11. Message data            |                      |
+       |<-------------------------|  |                      |
+----
+
+=== Key Design Principles
+
+1. **Task Separation**: I2C drivers run as separate tasks with memory isolation
+2. **IPC-Based Communication**: All operations use Hubris's synchronous IPC
+3. **No IDL**: Uses raw `sys_send` instead of Idol-generated code for flexibility
+4. **Type Safety**: Leverages Rust's type system and zero-copy serialization
+5. **Interrupt-Driven**: Slave mode uses notifications instead of polling
+6. **Device Identification**: 5-tuple uniquely identifies each I2C device
+
+== Device Identification
+
+Each I2C device is identified by a 5-tuple:
+
+[source,rust]
+----
+pub struct I2cDevice {
+    pub task: TaskId,              // I2C driver task
+    pub controller: Controller,     // I2C peripheral (I2C0-I2C7)
+    pub port: PortIndex,           // Pin configuration
+    pub segment: Option<(Mux, Segment)>, // Optional multiplexer
+    pub address: u8,               // 7-bit device address
+}
+----
+
+This design allows:
+- Multiple I2C controllers on the same chip
+- Multiple port configurations per controller
+- Multiplexed buses with segments
+- Clear device addressing without ambiguity
+
+== Operation Types
+
+=== Master Mode Operations
+
+Master mode operations are defined in link:../drv/i2c-types/src/lib.rs[`drv/i2c-types/src/lib.rs`]:
+
+[source,rust]
+----
+pub enum Op {
+    WriteRead = 1,          // Standard I2C transaction
+    WriteReadBlock = 2,     // SMBus block read
+    // ... slave mode operations below
+}
+----
+
+==== WriteRead (Op 1)
+
+Standard I2C write-then-read operation for register access.
+
+**Payload Structure:**
+[source]
+----
+[0]: Device address (7-bit)
+[1]: Controller index
+[2]: Port index
+[3]: Mux/segment byte (0x00 if none, or 0x80 | (mux << 4) | segment)
+
+Lease 0: Write data (register address, etc.)
+Lease 1: Read buffer
+----
+
+**Use Cases:**
+- Reading device registers
+- Writing configuration data
+- Combined write-read transactions
+
+==== WriteReadBlock (Op 2)
+
+SMBus block read where the final read operation returns variable-length data with a length byte.
+
+**Use Cases:**
+- SMBus block protocols
+- Devices that prefix data with length
+
+=== Slave Mode Operations
+
+Slave mode enables the I2C controller to act as a responder, critical for protocols like MCTP.
+
+==== ConfigureSlaveAddress (Op 3)
+
+Configure the I2C controller to respond to a specific 7-bit address.
+
+**Payload Structure:**
+[source]
+----
+[0]: Slave address (7-bit)
+[1]: Controller index
+[2]: Port index
+[3]: Reserved (0)
+----
+
+**Requirements:**
+- Address must not be reserved (see Reserved Address table)
+- Address must not already be in use
+- Controller must support slave mode
+
+**Errors:**
+- `BadSlaveAddress`: Address is reserved or invalid
+- `SlaveAddressInUse`: Address already configured
+- `SlaveNotSupported`: Hardware doesn't support slave mode
+
+==== EnableSlaveReceive (Op 4)
+
+Enable the hardware to receive messages at the configured slave address.
+
+**Payload Structure:**
+[source]
+----
+[0]: Unused (0)
+[1]: Controller index
+[2]: Port index
+[3]: Reserved (0)
+----
+
+**Behavior:**
+- Hardware begins accepting transactions to the slave address
+- Messages are buffered in hardware FIFO
+- Must be called after `ConfigureSlaveAddress`
+
+==== EnableSlaveNotification (Op 6)
+
+**NEW**: Enable interrupt-driven notifications when slave messages arrive.
+
+**Payload Structure:**
+[source]
+----
+[0]: Unused (0)
+[1]: Controller index
+[2]: Port index
+[3]: Reserved (0)
+
+Lease 0: Notification mask (u32)
+----
+
+**Behavior:**
+- I2C driver sends notification to calling task when messages arrive
+- Notification uses the provided mask (bitwise OR with task notifications)
+- Enables low-latency, power-efficient message reception
+- Must be called after `EnableSlaveReceive`
+
+**How Notifications Work:**
+The notification flow is indirect - the kernel does not deliver hardware interrupts directly to client tasks:
+
+1. Hardware interrupt fires → Kernel dispatches to I2C driver task
+2. Driver's interrupt handler reads message from hardware FIFO and buffers it
+3. Driver calls `sys_post(client_task_id, notification_mask)` to notify the client
+4. Kernel delivers the notification, unblocking client's `sys_recv_open()`
+5. Client calls `get_slave_message()` back to driver to retrieve buffered message
+
+The driver acts as an intermediary, translating hardware interrupts into task notifications using `sys_post`. This maintains task isolation while enabling interrupt-driven communication.
+
+**Task Requirements:**
+- Task must have I2C driver in `task-slots`
+- Notification bit must be in task's `notifications` array
+
+**Example Configuration:**
+[source,toml]
+----
+[tasks.mctp_server]
+task-slots = ["i2c_driver"]
+notifications = ["i2c-slave-rx", "timer"]
+----
+
+==== DisableSlaveNotification (Op 7)
+
+**NEW**: Disable interrupt-driven notifications.
+
+**Payload Structure:**
+[source]
+----
+[0]: Unused (0)
+[1]: Controller index
+[2]: Port index
+[3]: Reserved (0)
+----
+
+**Behavior:**
+- Stops sending notifications on message arrival
+- Messages still buffered (can be retrieved via polling)
+- Useful for temporarily suspending notifications
+
+==== GetSlaveMessage (Op 8)
+
+**NEW**: Retrieve a single slave message from the hardware receive buffer.
+
+**Payload Structure:**
+[source]
+----
+[0]: Unused (0)
+[1]: Controller index
+[2]: Port index
+[3]: Reserved (0)
+
+Lease 0: Receive buffer (at least 257 bytes)
+----
+
+**Response:**
+- Returns number of bytes written to buffer
+- Returns 0 if no messages available
+
+**Message Format in Buffer:**
+[source]
+----
+[0]: Source address (7-bit I2C address of sender)
+[1]: Message length (N)
+[2..N+1]: Message data
+----
+
+**Usage:**
+- Call on notification receipt for interrupt-driven mode
+- Call periodically for polling mode (not recommended)
+- Retrieves one message per call
+
+==== DisableSlaveReceive (Op 5)
+
+Disable slave receive mode.
+
+**Payload Structure:**
+[source]
+----
+[0]: Unused (0)
+[1]: Controller index
+[2]: Port index
+[3]: Reserved (0)
+----
+
+**Behavior:**
+- Hardware stops responding to slave address
+- Pending notifications are cleared
+- Buffered messages are discarded
+
+== API Methods
+
+=== Master Mode Methods
+
+Location: link:../drv/i2c-api/src/lib.rs[`drv/i2c-api/src/lib.rs`]
+
+==== read_reg<R, V>()
+
+Read a typed register value from a device.
+
+[source,rust]
+----
+pub fn read_reg<R, V>(&self, reg: R) -> Result<V, ResponseCode>
+where
+    R: IntoBytes + Immutable,
+    V: IntoBytes + FromBytes,
+----
+
+**Example:**
+[source,rust]
+----
+let temp: u16 = device.read_reg(0x00u8)?;
+----
+
+==== write<V>()
+
+Write data to a device.
+
+[source,rust]
+----
+pub fn write<V: IntoBytes + Immutable>(&self, value: V) -> Result<(), ResponseCode>
+----
+
+==== write_read_reg<R, V>()
+
+Combined write-then-read transaction.
+
+[source,rust]
+----
+pub fn write_read_reg<R, V>(
+    &self,
+    reg: R,
+    value: V,
+) -> Result<(), ResponseCode>
+----
+
+=== Slave Mode Methods
+
+==== configure_slave_address()
+
+Configure the controller to respond as a slave.
+
+[source,rust]
+----
+pub fn configure_slave_address(&self, slave_address: u8) -> Result<(), ResponseCode>
+----
+
+**Example:**
+[source,rust]
+----
+let device = I2cDevice::new(i2c_task, Controller::I2C1, PortIndex(0), None, 0x1D);
+device.configure_slave_address(0x1D)?;
+----
+
+==== enable_slave_receive()
+
+Begin buffering incoming slave messages.
+
+[source,rust]
+----
+pub fn enable_slave_receive(&self) -> Result<(), ResponseCode>
+----
+
+==== enable_slave_notification()
+
+**NEW**: Enable interrupt-driven notifications.
+
+[source,rust]
+----
+pub fn enable_slave_notification(&self, notification_mask: u32) -> Result<(), ResponseCode>
+----
+
+**Example:**
+[source,rust]
+----
+const I2C_RX_NOTIF: u32 = 0x0001;
+device.enable_slave_notification(I2C_RX_NOTIF)?;
+
+// In event loop
+loop {
+    let msg = sys_recv_open(&mut buf, I2C_RX_NOTIF);
+    if msg.sender == TaskId::KERNEL && (msg.operation & I2C_RX_NOTIF) != 0 {
+        let slave_msg = device.get_slave_message()?;
+        process(slave_msg);
+    }
+}
+----
+
+==== disable_slave_notification()
+
+**NEW**: Disable interrupt-driven notifications.
+
+[source,rust]
+----
+pub fn disable_slave_notification(&self) -> Result<(), ResponseCode>
+----
+
+==== get_slave_message()
+
+**NEW**: Retrieve one message from hardware buffer.
+
+[source,rust]
+----
+pub fn get_slave_message(&self) -> Result<SlaveMessage, ResponseCode>
+----
+
+**Returns:**
+- `Ok(SlaveMessage)`: Message retrieved successfully
+- `Err(NoSlaveMessage)`: No message available
+- `Err(...)`: Other errors
+
+==== disable_slave_receive()
+
+Stop slave mode operation.
+
+[source,rust]
+----
+pub fn disable_slave_receive(&self) -> Result<(), ResponseCode>
+----
+
+=== Deprecated Methods
+
+==== check_slave_buffer()
+
+**DEPRECATED**: Use `get_slave_message()` with notifications instead.
+
+[source,rust]
+----
+#[deprecated(since = "0.2.0")]
+pub fn check_slave_buffer(&self, buffer: &mut [u8]) -> Result<usize, ResponseCode>
+----
+
+**Why Deprecated:**
+- Requires polling (inefficient)
+- High latency
+- Wastes CPU cycles
+- Poor power efficiency
+
+==== get_slave_messages()
+
+**DEPRECATED**: Use `get_slave_message()` directly.
+
+[source,rust]
+----
+#[deprecated(since = "0.2.0")]
+pub fn get_slave_messages(&self, messages: &mut [SlaveMessage]) -> Result<usize, ResponseCode>
+----
+
+**Why Deprecated:**
+- Polling-based
+- Multi-message retrieval not needed with notifications
+
+== Error Codes
+
+Defined in link:../drv/i2c-types/src/lib.rs[`drv/i2c-types/src/lib.rs`]:
+
+[cols="1,3"]
+|===
+|Error Code |Description
+
+|`BadResponse`
+|Invalid response from server
+
+|`BadArg`
+|Invalid argument in request
+
+|`NoDevice`
+|I2C device doesn't exist
+
+|`BadController`
+|Invalid controller index
+
+|`ReservedAddress`
+|Address is reserved by I2C spec
+
+|`BadPort`
+|Invalid port index
+
+|`NoRegister`
+|Device doesn't have requested register
+
+|`BusReset`
+|I2C bus was reset during operation
+
+|`BusLocked`
+|I2C bus locked up and was reset
+
+|`ControllerBusy`
+|Controller appeared busy and was reset
+
+|`BusError`
+|General I2C bus error
+
+|`OperationNotSupported`
+|Operation not supported on this hardware
+
+|`TooMuchData`
+|Data exceeds buffer capacity
+
+|`SlaveAddressInUse`
+|Slave address already configured
+
+|`SlaveNotSupported`
+|Slave mode not supported on controller
+
+|`SlaveNotEnabled`
+|Slave receive not enabled
+
+|`SlaveBufferFull`
+|Hardware buffer full, messages dropped
+
+|`BadSlaveAddress`
+|Invalid slave address (reserved or out of range)
+
+|`SlaveConfigurationFailed`
+|Hardware failed to configure slave mode
+
+|`NoSlaveMessage`
+|No slave message available to retrieve
+
+|`NotificationFailed`
+|Failed to register notification
+|===
+
+== Reserved I2C Addresses
+
+Per I2C specification, certain addresses are reserved:
+
+[cols="1,2,3"]
+|===
+|Address (7-bit) |Binary |Purpose
+
+|0x00
+|0000000
+|General Call
+
+|0x01
+|0000001
+|CBUS Address
+
+|0x02
+|0000010
+|Future Bus Reserved
+
+|0x03
+|0000011
+|Future Purposes
+
+|0x04-0x07
+|000010x
+|High Speed Reserved
+
+|0x78-0x7B
+|111110x
+|10-bit Addressing
+
+|0x7C-0x7F
+|111111x
+|Reserved
+|===
+
+The API will reject attempts to use reserved addresses in `configure_slave_address()`.
+
+== Usage Patterns
+
+=== Standard Master Operation
+
+[source,rust]
+----
+use drv_i2c_api::*;
+use userlib::TaskId;
+
+// Create device handle
+let sensor = I2cDevice::new(
+    i2c_task,
+    Controller::I2C1,
+    PortIndex(0),
+    None,  // No multiplexer
+    0x48,  // Temperature sensor address
+);
+
+// Read temperature register
+let temp: u16 = sensor.read_reg(0x00u8)?;
+
+// Write configuration
+sensor.write_read_reg(0x01u8, 0x80u8)?;
+----
+
+=== Interrupt-Driven Slave Mode (Recommended)
+
+[source,rust]
+----
+use drv_i2c_api::*;
+use userlib::*;
+
+task_slot!(I2C, i2c_driver);
+
+const I2C_RX_NOTIF: u32 = 0x0001;
+
+fn main() -> ! {
+    // Setup slave mode
+    let device = I2cDevice::new(
+        I2C.get_task_id(),
+        Controller::I2C1,
+        PortIndex(0),
+        None,
+        0x1D,  // Our slave address
+    );
+    
+    device.configure_slave_address(0x1D).unwrap_lite();
+    device.enable_slave_receive().unwrap_lite();
+    device.enable_slave_notification(I2C_RX_NOTIF).unwrap_lite();
+    
+    let mut msg_buf = [0u8; 256];
+    
+    loop {
+        let msg = sys_recv_open(&mut msg_buf, I2C_RX_NOTIF);
+        
+        if msg.sender == TaskId::KERNEL 
+            && (msg.operation & I2C_RX_NOTIF) != 0 
+        {
+            // Notification: message arrived
+            match device.get_slave_message() {
+                Ok(slave_msg) => {
+                    // Process immediately
+                    let source = slave_msg.source_address;
+                    let data = slave_msg.data();
+                    handle_message(source, data);
+                }
+                Err(ResponseCode::NoSlaveMessage) => {
+                    // Spurious notification, continue
+                }
+                Err(e) => {
+                    // Handle error
+                }
+            }
+        }
+    }
+}
+
+fn handle_message(source: u8, data: &[u8]) {
+    // Process received message
+}
+----
+
+=== Polling Mode (Legacy - Not Recommended)
+
+[source,rust]
+----
+use drv_i2c_api::*;
+
+// Setup slave mode
+device.configure_slave_address(0x1D)?;
+device.enable_slave_receive()?;
+
+// Poll for messages (inefficient!)
+loop {
+    match device.get_slave_message() {
+        Ok(message) => {
+            process_message(message);
+        }
+        Err(ResponseCode::NoSlaveMessage) => {
+            // No message, continue polling
+            // This wastes CPU and power!
+        }
+        Err(e) => {
+            // Handle error
+        }
+    }
+}
+----
+
+== Design Rationale
+
+=== Why Not Use Idol?
+
+The I2C API uses raw `sys_send` instead of Idol-generated IPC for several reasons:
+
+1. **Flexibility**: Variable-length lease handling without code generation complexity
+2. **Legacy**: Predates some Idol features, works well
+3. **Performance**: Direct control over serialization and IPC layout
+4. **Simplicity**: Easier to understand for embedded developers
+
+However, future work might consider Idol for consistency with other APIs.
+
+=== Why Separate Operations for Notifications?
+
+Rather than automatically enabling notifications with `enable_slave_receive()`, we use a separate operation:
+
+**Advantages:**
+- Allows polling mode without notifications (backwards compatible)
+- Client controls when notifications start (after setup complete)
+- Can change notification mask without disabling slave mode
+- Clear separation of concerns
+
+**Implementation:**
+[source,rust]
+----
+device.enable_slave_receive()?;      // Hardware starts receiving
+device.enable_slave_notification(mask)?;  // Notifications enabled
+----
+
+=== Why Single Message Retrieval?
+
+`GetSlaveMessage` returns one message at a time instead of batching multiple messages:
+
+**Rationale:**
+- Natural for interrupt-driven processing (one notification → one message)
+- Simplifies buffer management
+- Reduces latency (process immediately)
+- Prevents stale data accumulation
+- Matches hardware FIFO behavior
+
+**Performance:**
+- Each notification typically corresponds to one message received
+- Subsequent messages trigger new notifications
+- No need to poll for remaining messages
+
+=== Why Deprecate Instead of Remove?
+
+Old polling methods are deprecated but not removed:
+
+**Rationale:**
+- Backwards compatibility with existing code
+- Allows gradual migration
+- Provides fallback if hardware doesn't support interrupts
+- Clear migration path with deprecation warnings
+
+## Requirements for Driver Implementation
+
+I2C driver tasks implementing this API must:
+
+=== Required Operations
+
+1. **Implement all Op enum variants** defined in `drv-i2c-types`
+2. **Handle IPC marshalling** for 5-tuple device identification
+3. **Support leases** for variable-length data transfer
+4. **Return proper error codes** from `ResponseCode` enum
+
+=== Slave Mode Requirements
+
+1. **Hardware Configuration**:
+   - Configure slave address in I2C controller
+   - Enable slave receive mode in hardware
+   - Configure receive FIFO or buffers
+
+2. **Interrupt Handling**:
+   - Register slave RX interrupt handler
+   - Read message data from hardware on interrupt
+   - Store notification mask per controller/port
+
+3. **Notification Delivery**:
+   - Send notification to client task on message arrival using `sys_post(client_task, mask)`
+   - Track which task to notify (stored during `EnableSlaveNotification`)
+   - Handle spurious interrupts gracefully
+   - Note: Driver acts as intermediary between hardware interrupt and client notification
+
+4. **Message Buffering**:
+   - Buffer at least one complete message
+   - Handle hardware FIFO overflow
+   - Implement proper flow control
+
+5. **State Management**:
+   - Track slave address per controller/port
+   - Track notification state per controller/port
+   - Handle task restarts/generation changes
+
+=== Error Handling Requirements
+
+1. **Bus Errors**: Reset and recover from bus lockups
+2. **Invalid Addresses**: Reject reserved addresses
+3. **Resource Conflicts**: Detect address/port conflicts
+4. **Hardware Limitations**: Report unsupported features clearly
+
+=== Example Driver Skeleton
+
+[source,rust]
+----
+fn handle_enable_slave_notification(
+    controller: Controller,
+    port: PortIndex,
+    notification_mask: u32,
+    caller_task: TaskId,
+) -> Result<(), ResponseCode> {
+    // 1. Validate controller supports slave mode
+    if !hardware_supports_slave(controller) {
+        return Err(ResponseCode::SlaveNotSupported);
+    }
+    
+    // 2. Store notification info
+    self.slave_notifications
+        .insert((controller, port), (caller_task, notification_mask));
+    
+    // 3. Enable interrupt in hardware
+    hardware_enable_slave_rx_interrupt(controller)?;
+    
+    Ok(())
+}
+
+fn slave_rx_interrupt_handler(&mut self, controller: Controller) {
+    // 1. Read message from hardware FIFO
+    let message = hardware_read_slave_message(controller);
+    
+    // 2. Buffer the message
+    self.slave_buffers.insert(controller, message);
+    
+    // 3. Post notification to client
+    if let Some((task, mask)) = self.slave_notifications.get(controller) {
+        sys_post(*task, *mask);
+    }
+}
+----
+
+== Future Enhancements
+
+=== Potential Improvements
+
+1. **Multi-Address Slave Mode**:
+   - Support multiple slave addresses per controller
+   - Useful for address translation or proxying
+
+2. **SMBus ARP Support**:
+   - Address Resolution Protocol
+   - Dynamic address assignment
+
+3. **Clock Stretching Control**:
+   - Fine-grained control over clock stretching behavior
+   - Timeout configuration
+
+4. **Enhanced Diagnostics**:
+   - Transaction counters
+   - Error statistics
+   - Performance metrics
+
+5. **DMA Support**:
+   - Large transfer optimization
+   - Reduced CPU overhead
+
+6. **Multi-Master Arbitration**:
+   - Better support for multi-master scenarios
+   - Arbitration loss handling
+
+=== Migration to Idol
+
+Future versions might migrate to Idol for consistency:
+
+**Advantages:**
+- Automatic client/server stub generation
+- Type-safe IPC
+- Standard error handling
+- Built-in retry logic
+
+**Challenges:**
+- Lease handling complexity
+- Migration path for existing code
+- Performance implications
+
+== Related Documentation
+
+- link:mctp-i2c-transport.adoc[MCTP I2C Transport Design]
+- link:ipc.adoc[Hubris IPC System]
+- link:guide/drivers.adoc[Driver Development Guide]
+- link:guide/servers.adoc[Server Implementation Guide]
+
+== Conclusion
+
+The I2C API provides a robust, type-safe interface for I2C communication in Hubris applications. The recent addition of interrupt-driven slave mode support enables efficient implementation of peer-to-peer protocols like MCTP while maintaining backwards compatibility with polling-based code.
+
+Key design decisions prioritize:
+- **Safety**: Memory isolation and type safety
+- **Performance**: Interrupt-driven operation
+- **Flexibility**: Support for both master and slave modes
+- **Maintainability**: Clear operation semantics and error handling
+- **Compatibility**: Gradual migration path from polling to notifications
+
+This design serves as a foundation for reliable I2C communication in embedded systems requiring both traditional peripheral access and modern management protocols.

--- a/drv/ast1060-uart/src/main.rs
+++ b/drv/ast1060-uart/src/main.rs
@@ -73,13 +73,13 @@ fn main() -> ! {
                             if rx_buf.push_back(byte).is_err() {
                                 overflow = true;
                             }
-                            if rx_buf.len() > buffer_len {
-                                if let Some((task, notification_bit)) =
-                                    notify_rx_data
-                                {
-                                    // Notify the task that data is available.
-                                    sys_post(task, 1 << notification_bit);
-                                }
+                        }
+                        if rx_buf.len() > buffer_len {
+                            if let Some((task, notification_bit)) =
+                                notify_rx_data
+                            {
+                                // Notify the task that data is available.
+                                sys_post(task, 1 << notification_bit);
                             }
                         }
                     }

--- a/drv/i2c-types/src/lib.rs
+++ b/drv/i2c-types/src/lib.rs
@@ -430,6 +430,16 @@ impl SlaveMessage {
     }
 }
 
+impl Default for SlaveMessage {
+    fn default() -> Self {
+        Self {
+            source_address: 0,
+            data_length: 0,
+            data: [0; 255],
+        }
+    }
+}
+
 /// Configuration for I2C slave mode operation
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, SerializedSize)]
 pub struct SlaveConfig {

--- a/drv/openprot-i2c-server/src/main.rs
+++ b/drv/openprot-i2c-server/src/main.rs
@@ -156,20 +156,42 @@ fn main() -> ! {
                 caller.reply(0usize);
                 Ok(())
             }
-            Op::CheckSlaveBuffer => {
-                // Use the same marshal format as WriteRead operations
+            Op::EnableSlaveNotification => {
+                // Enable interrupt-driven notifications
                 let (payload, caller) = msg
                     .fixed::<[u8; 4], usize>()
                     .ok_or(ResponseCode::BadArg)?;
 
                 let (_address, controller, _port, _segment) = Marshal::unmarshal(payload)?;
                 
-                // Check for slave messages - for now just return count
-                // A full implementation would need to handle message data formatting
-                let temp_messages: [u8; 0] = []; // Empty for mock
-                let count = temp_messages.len();
+                // Mock implementation - would configure interrupt notifications in real hardware
+                // For now, just acknowledge the operation
+                caller.reply(0usize);
+                Ok(())
+            }
+            Op::DisableSlaveNotification => {
+                // Disable interrupt-driven notifications
+                let (payload, caller) = msg
+                    .fixed::<[u8; 4], usize>()
+                    .ok_or(ResponseCode::BadArg)?;
+
+                let (_address, controller, _port, _segment) = Marshal::unmarshal(payload)?;
                 
-                caller.reply(count);
+                // Mock implementation - would disable interrupt notifications in real hardware
+                caller.reply(0usize);
+                Ok(())
+            }
+            Op::GetSlaveMessage => {
+                // Retrieve a single slave message
+                let (payload, caller) = msg
+                    .fixed::<[u8; 4], usize>()
+                    .ok_or(ResponseCode::BadArg)?;
+
+                let (_address, controller, _port, _segment) = Marshal::unmarshal(payload)?;
+                
+                // Mock implementation - return no message available
+                // A real implementation would read from hardware FIFO
+                caller.reply(0usize); // 0 bytes = no message
                 Ok(())
             }
         });

--- a/drv/openprot-i2c-server/src/main.rs
+++ b/drv/openprot-i2c-server/src/main.rs
@@ -1,14 +1,19 @@
 //! Mock I2C Server - Embedded Binary
 //!
 //! This is the embedded binary entry point for the mock I2C server driver.
+//! 
+//! This implementation uses manual IPC handling (like the UART driver) to support
+//! timer notifications for injecting test slave messages asynchronously.
 
 #![no_std]
 #![no_main]
 
 use drv_i2c_api::*;
-use drv_i2c_types::{traits::I2cHardware, Op, ResponseCode};
+use drv_i2c_types::{traits::I2cHardware, Op, ResponseCode, SlaveMessage};
 
-use userlib::{hl, LeaseAttributes};
+use userlib::{LeaseAttributes, sys_recv_open, sys_reply, sys_borrow_info, 
+              sys_borrow_read, sys_borrow_write, sys_post, set_timer_relative, 
+              TaskId, RecvMessage, FromPrimitive};
 use ringbuf::*;
 
 mod mock_driver;
@@ -26,174 +31,411 @@ enum Trace {
 
 counted_ringbuf!(Trace, 64, Trace::None);
 
+// Timer configuration for injecting test slave messages
+const TIMER_INTERVAL_MS: u32 = 100;  // Generate test message every 100ms
+const TIMER_NOTIF: u32 = 0x0001;      // Timer notification bit
+
 #[export_name = "main"]
 fn main() -> ! {
     // Create Mock I2C driver on the stack for IPC testing
     let mut driver = MockI2cDriver::new();
     
-    // Optional: Configure driver for specific test scenarios
-    // Example: driver.set_device_response(Controller::I2C0, 0x50, &[0x12, 0x34]).ok();
+    // State for notification-driven slave message injection
+    let mut notification_client: Option<(TaskId, u32)> = None;
+    let mut timer_armed: bool = false;
 
-    // Field messages
-    let mut buffer = [0; 4];
+    // Message buffer for IPC
+    let mut buffer = [0u8; 4];
 
     loop {
-        hl::recv_without_notification(&mut buffer, |op, msg| match op {
-            Op::WriteRead | Op::WriteReadBlock => {
-                let lease_count = msg.lease_count();
-
-                let (payload, caller) = msg
-                    .fixed::<[u8; 4], usize>()
-                    .ok_or(ResponseCode::BadArg)?;
-
-                if lease_count < 2 || lease_count % 2 != 0 {
-                    return Err(ResponseCode::BadArg);
+        let msginfo = sys_recv_open(&mut buffer, TIMER_NOTIF);
+        
+        // Handle timer notification - inject slave message
+        if msginfo.sender == TaskId::KERNEL {
+            if msginfo.operation & TIMER_NOTIF != 0 {
+                if let Some((client_task, notif_mask)) = notification_client {
+                    // Inject a test slave message
+                    if driver.inject_slave_message().is_ok() {
+                        // Notify the client that a message is available
+                        sys_post(client_task, notif_mask);
+                    }
+                    
+                    // Re-arm timer for next message if still enabled
+                    if timer_armed {
+                        set_timer_relative(TIMER_INTERVAL_MS, TIMER_NOTIF);
+                    }
                 }
-
-                // For mock mode, we use the standard marshal format but ignore complex topology
-                let (addr, controller, _port, _mux) = Marshal::unmarshal(payload)?;
-
-                let mut total = 0;
-
-                // Iterate over write/read pairs
-                for i in (0..lease_count).step_by(2) {
-                    let wbuf = caller.borrow(i);
-                    let winfo = wbuf.info().ok_or(ResponseCode::BadArg)?;
-
-                    if !winfo.attributes.contains(LeaseAttributes::READ) {
-                        return Err(ResponseCode::BadArg);
-                    }
-
-                    let rbuf = caller.borrow(i + 1);
-                    let rinfo = rbuf.info().ok_or(ResponseCode::BadArg)?;
-
-                    if winfo.len == 0 && rinfo.len == 0 {
-                        return Err(ResponseCode::BadArg);
-                    }
-
-                    if winfo.len > 255 || rinfo.len > 255 {
-                        // Keep the 255 limit as per IPC protocol
-                        return Err(ResponseCode::BadArg);
-                    }
-
-                    // Read write data from lease
-                    let mut write_data = [0u8; 255];
-                    for pos in 0..winfo.len {
-                        write_data[pos] = wbuf.read_at(pos).ok_or(ResponseCode::BadArg)?;
-                    }
-
-                    // Prepare read buffer
-                    let mut read_buffer = [0u8; 255];
-                    let read_slice = &mut read_buffer[..rinfo.len];
-
-                    // Perform the I2C transaction
-                    let bytes_read = if op == Op::WriteReadBlock {
-                        driver.write_read_block(
-                            controller,
-                            addr,
-                            &write_data[..winfo.len],
-                            read_slice,
-                        )?
-                    } else {
-                        driver.write_read(
-                            controller,
-                            addr,
-                            &write_data[..winfo.len],
-                            read_slice,
-                        )?
-                    };
-
-                    // Write read data back to lease
-                    for pos in 0..bytes_read.min(rinfo.len) {
-                        rbuf.write_at(pos, read_slice[pos]).ok_or(ResponseCode::BadArg)?;
-                    }
-
-                    total += bytes_read;
-                }
-
-                caller.reply(total);
-                Ok(())
             }
-            Op::ConfigureSlaveAddress => {
-                // Use the same marshal format as WriteRead operations
-                let (payload, caller) = msg
-                    .fixed::<[u8; 4], usize>()
-                    .ok_or(ResponseCode::BadArg)?;
-
-                let (slave_address, controller, port, _segment) = Marshal::unmarshal(payload)?;
-                
-                // Create slave configuration  
-                let config = SlaveConfig::new(controller, port, slave_address)
-                    .map_err(|_| ResponseCode::BadArg)?;
-                
-                // Configure slave mode on hardware
-                driver.configure_slave_mode(controller, &config)?;
-                
-                caller.reply(0usize);
-                Ok(())
+            continue;
+        }
+        
+        // Decode operation
+        let op = match Op::from_u32(msginfo.operation) {
+            Some(op) => op,
+            None => {
+                sys_reply(msginfo.sender, 1, &[]); // Bad operation
+                continue;
             }
-            Op::EnableSlaveReceive => {
-                // Use the same marshal format as WriteRead operations
-                let (payload, caller) = msg
-                    .fixed::<[u8; 4], usize>()
-                    .ok_or(ResponseCode::BadArg)?;
-
-                let (_address, controller, _port, _segment) = Marshal::unmarshal(payload)?;
-                
-                driver.enable_slave_receive(controller)?;
-                caller.reply(0usize);
-                Ok(())
-            }
-            Op::DisableSlaveReceive => {
-                // Use the same marshal format as WriteRead operations
-                let (payload, caller) = msg
-                    .fixed::<[u8; 4], usize>()
-                    .ok_or(ResponseCode::BadArg)?;
-
-                let (_address, controller, _port, _segment) = Marshal::unmarshal(payload)?;
-                
-                driver.disable_slave_receive(controller)?;
-                caller.reply(0usize);
-                Ok(())
-            }
-            Op::EnableSlaveNotification => {
-                // Enable interrupt-driven notifications
-                let (payload, caller) = msg
-                    .fixed::<[u8; 4], usize>()
-                    .ok_or(ResponseCode::BadArg)?;
-
-                let (_address, controller, _port, _segment) = Marshal::unmarshal(payload)?;
-                
-                // Mock implementation - would configure interrupt notifications in real hardware
-                // For now, just acknowledge the operation
-                caller.reply(0usize);
-                Ok(())
-            }
-            Op::DisableSlaveNotification => {
-                // Disable interrupt-driven notifications
-                let (payload, caller) = msg
-                    .fixed::<[u8; 4], usize>()
-                    .ok_or(ResponseCode::BadArg)?;
-
-                let (_address, controller, _port, _segment) = Marshal::unmarshal(payload)?;
-                
-                // Mock implementation - would disable interrupt notifications in real hardware
-                caller.reply(0usize);
-                Ok(())
-            }
-            Op::GetSlaveMessage => {
-                // Retrieve a single slave message
-                let (payload, caller) = msg
-                    .fixed::<[u8; 4], usize>()
-                    .ok_or(ResponseCode::BadArg)?;
-
-                let (_address, controller, _port, _segment) = Marshal::unmarshal(payload)?;
-                
-                // Mock implementation - return no message available
-                // A real implementation would read from hardware FIFO
-                caller.reply(0usize); // 0 bytes = no message
-                Ok(())
-            }
-        });
+        };
+        
+        // Handle IPC operation
+        handle_operation(op, &msginfo, &mut buffer, &mut driver, &mut notification_client, &mut timer_armed);
     }
 }
+
+fn handle_operation(
+    op: Op,
+    msginfo: &RecvMessage,
+    buffer: &mut [u8],
+    driver: &mut MockI2cDriver,
+    notification_client: &mut Option<(TaskId, u32)>,
+    timer_armed: &mut bool,
+) {
+    match op {
+        Op::WriteRead | Op::WriteReadBlock => {
+            handle_write_read(op, msginfo, buffer, driver);
+        }
+        Op::ConfigureSlaveAddress => {
+            handle_configure_slave_address(msginfo, buffer, driver);
+        }
+        Op::EnableSlaveReceive => {
+            handle_enable_slave_receive(msginfo, buffer, driver);
+        }
+        Op::DisableSlaveReceive => {
+            handle_disable_slave_receive(msginfo, buffer, driver);
+        }
+        Op::EnableSlaveNotification => {
+            handle_enable_slave_notification(msginfo, buffer, notification_client, timer_armed);
+        }
+        Op::DisableSlaveNotification => {
+            handle_disable_slave_notification(msginfo, notification_client, timer_armed);
+        }
+        Op::GetSlaveMessage => {
+            handle_get_slave_message(msginfo, buffer, driver);
+        }
+    }
+}
+
+fn handle_write_read(
+    op: Op,
+    msginfo: &RecvMessage,
+    buffer: &[u8],
+    driver: &mut MockI2cDriver,
+) {
+    let lease_count = msginfo.lease_count;
+    
+    if lease_count < 2 || lease_count % 2 != 0 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    // Extract marshal payload from buffer
+    if msginfo.message_len < 4 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    let payload: [u8; 4] = [buffer[0], buffer[1], buffer[2], buffer[3]];
+    let (addr, controller, _port, _mux) = match Marshal::unmarshal(&payload) {
+        Ok(vals) => vals,
+        Err(e) => {
+            sys_reply(msginfo.sender, e as u32, &[]);
+            return;
+        }
+    };
+    
+    let mut total = 0;
+    
+    // Iterate over write/read pairs
+    for i in (0..lease_count).step_by(2) {
+        // Get write buffer info
+        let winfo = match sys_borrow_info(msginfo.sender, i) {
+            Some(info) => info,
+            None => {
+                sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+                return;
+            }
+        };
+        
+        if !winfo.attributes.contains(LeaseAttributes::READ) {
+            sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+            return;
+        }
+        
+        // Get read buffer info
+        let rinfo = match sys_borrow_info(msginfo.sender, i + 1) {
+            Some(info) => info,
+            None => {
+                sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+                return;
+            }
+        };
+        
+        if winfo.len == 0 && rinfo.len == 0 {
+            sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+            return;
+        }
+        
+        if winfo.len > 255 || rinfo.len > 255 {
+            sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+            return;
+        }
+        
+        // Read write data from lease
+        let mut write_data = [0u8; 255];
+        for pos in 0..winfo.len {
+            let (rc, _) = sys_borrow_read(msginfo.sender, i, pos, &mut write_data[pos..pos+1]);
+            if rc != 0 {
+                sys_reply(msginfo.sender, rc, &[]);
+                return;
+            }
+        }
+        
+        // Prepare read buffer
+        let mut read_buffer = [0u8; 255];
+        let read_slice = &mut read_buffer[..rinfo.len];
+        
+        // Perform the I2C transaction
+        let bytes_read = if op == Op::WriteReadBlock {
+            match driver.write_read_block(controller, addr, &write_data[..winfo.len], read_slice) {
+                Ok(n) => n,
+                Err(e) => {
+                    sys_reply(msginfo.sender, e as u32, &[]);
+                    return;
+                }
+            }
+        } else {
+            match driver.write_read(controller, addr, &write_data[..winfo.len], read_slice) {
+                Ok(n) => n,
+                Err(e) => {
+                    sys_reply(msginfo.sender, e as u32, &[]);
+                    return;
+                }
+            }
+        };
+        
+        // Write read data back to lease
+        for pos in 0..bytes_read.min(rinfo.len) {
+            let (rc, _) = sys_borrow_write(msginfo.sender, i + 1, pos, &read_slice[pos..pos+1]);
+            if rc != 0 {
+                sys_reply(msginfo.sender, rc, &[]);
+                return;
+            }
+        }
+        
+        total += bytes_read;
+    }
+    
+    sys_reply(msginfo.sender, 0, &total.to_le_bytes());
+}
+
+fn handle_configure_slave_address(
+    msginfo: &RecvMessage,
+    buffer: &[u8],
+    driver: &mut MockI2cDriver,
+) {
+    if msginfo.message_len < 4 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    let payload: [u8; 4] = [buffer[0], buffer[1], buffer[2], buffer[3]];
+    let (slave_address, controller, port, _segment) = match Marshal::unmarshal(&payload) {
+        Ok(vals) => vals,
+        Err(e) => {
+            sys_reply(msginfo.sender, e as u32, &[]);
+            return;
+        }
+    };
+    
+    use drv_i2c_types::SlaveConfig;
+    let config = match SlaveConfig::new(controller, port, slave_address) {
+        Ok(c) => c,
+        Err(_) => {
+            sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+            return;
+        }
+    };
+    
+    match driver.configure_slave_mode(controller, &config) {
+        Ok(()) => sys_reply(msginfo.sender, 0, &[]),
+        Err(e) => sys_reply(msginfo.sender, e as u32, &[]),
+    }
+}
+
+fn handle_enable_slave_receive(
+    msginfo: &RecvMessage,
+    buffer: &[u8],
+    driver: &mut MockI2cDriver,
+) {
+    if msginfo.message_len < 4 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    let payload: [u8; 4] = [buffer[0], buffer[1], buffer[2], buffer[3]];
+    let (_address, controller, _port, _segment) = match Marshal::unmarshal(&payload) {
+        Ok(vals) => vals,
+        Err(e) => {
+            sys_reply(msginfo.sender, e as u32, &[]);
+            return;
+        }
+    };
+    
+    match driver.enable_slave_receive(controller) {
+        Ok(()) => sys_reply(msginfo.sender, 0, &[]),
+        Err(e) => sys_reply(msginfo.sender, e as u32, &[]),
+    }
+}
+
+fn handle_disable_slave_receive(
+    msginfo: &RecvMessage,
+    buffer: &[u8],
+    driver: &mut MockI2cDriver,
+) {
+    if msginfo.message_len < 4 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    let payload: [u8; 4] = [buffer[0], buffer[1], buffer[2], buffer[3]];
+    let (_address, controller, _port, _segment) = match Marshal::unmarshal(&payload) {
+        Ok(vals) => vals,
+        Err(e) => {
+            sys_reply(msginfo.sender, e as u32, &[]);
+            return;
+        }
+    };
+    
+    match driver.disable_slave_receive(controller) {
+        Ok(()) => sys_reply(msginfo.sender, 0, &[]),
+        Err(e) => sys_reply(msginfo.sender, e as u32, &[]),
+    }
+}
+
+fn handle_enable_slave_notification(
+    msginfo: &RecvMessage,
+    buffer: &[u8],
+    notification_client: &mut Option<(TaskId, u32)>,
+    timer_armed: &mut bool,
+) {
+    if msginfo.message_len < 4 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    // Check for lease with notification mask
+    if msginfo.lease_count < 1 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    let lease_info = match sys_borrow_info(msginfo.sender, 0) {
+        Some(info) => info,
+        None => {
+            sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+            return;
+        }
+    };
+    
+    if lease_info.len < 4 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    // Read notification mask from lease (u32, 4 bytes)
+    let mut mask_bytes = [0u8; 4];
+    for i in 0..4 {
+        let (rc, _) = sys_borrow_read(msginfo.sender, 0, i, &mut mask_bytes[i..i+1]);
+        if rc != 0 {
+            sys_reply(msginfo.sender, rc, &[]);
+            return;
+        }
+    }
+    let notif_mask = u32::from_le_bytes(mask_bytes);
+    
+    // Store client info and start timer
+    *notification_client = Some((msginfo.sender, notif_mask));
+    *timer_armed = true;
+    set_timer_relative(TIMER_INTERVAL_MS, TIMER_NOTIF);
+    
+    sys_reply(msginfo.sender, 0, &[]);
+}
+
+fn handle_disable_slave_notification(
+    msginfo: &RecvMessage,
+    notification_client: &mut Option<(TaskId, u32)>,
+    timer_armed: &mut bool,
+) {
+    // Clear notification state and stop timer
+    *notification_client = None;
+    *timer_armed = false;
+    
+    sys_reply(msginfo.sender, 0, &[]);
+}
+
+fn handle_get_slave_message(
+    msginfo: &RecvMessage,
+    buffer: &[u8],
+    driver: &mut MockI2cDriver,
+) {
+    if msginfo.message_len < 4 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    let payload: [u8; 4] = [buffer[0], buffer[1], buffer[2], buffer[3]];
+    let (_address, controller, _port, _segment) = match Marshal::unmarshal(&payload) {
+        Ok(vals) => vals,
+        Err(e) => {
+            sys_reply(msginfo.sender, e as u32, &[]);
+            return;
+        }
+    };
+    
+    // Check that we have a lease for returning the message
+    if msginfo.lease_count < 1 {
+        sys_reply(msginfo.sender, ResponseCode::BadArg as u32, &[]);
+        return;
+    }
+    
+    // Try to get a message from the driver
+    let mut messages = [SlaveMessage::default(); 1];
+    match driver.poll_slave_messages(controller, &mut messages) {
+        Ok(1) => {
+            // Message available - write to lease
+            let slave_msg = &messages[0];
+            
+            // Write: source_address (1 byte) + data_length (1 byte) + data
+            let mut write_buf = [0u8; 257]; // max: 2 + 255
+            write_buf[0] = slave_msg.source_address;
+            write_buf[1] = slave_msg.data_length;
+            write_buf[2..2 + slave_msg.data_length as usize]
+                .copy_from_slice(&slave_msg.data[..slave_msg.data_length as usize]);
+            
+            let total_len = 2 + slave_msg.data_length as usize;
+            for i in 0..total_len {
+                let (rc, _) = sys_borrow_write(msginfo.sender, 0, i, &write_buf[i..i+1]);
+                if rc != 0 {
+                    sys_reply(msginfo.sender, rc, &[]);
+                    return;
+                }
+            }
+            
+            sys_reply(msginfo.sender, 0, &total_len.to_le_bytes());
+        }
+        Ok(0) => {
+            // No message available
+            sys_reply(msginfo.sender, ResponseCode::NoSlaveMessage as u32, &[]);
+        }
+        Ok(_) => {
+            // Unexpected count
+            sys_reply(msginfo.sender, ResponseCode::BadResponse as u32, &[]);
+        }
+        Err(e) => {
+            sys_reply(msginfo.sender, e as u32, &[]);
+        }
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/notifications.rs"));

--- a/lib/ast1060-uart-log/Cargo.toml
+++ b/lib/ast1060-uart-log/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ast1060-uart-log"
+version = "0.1.0"
+edition = "2021"
+description = "Print log messages over the AST1060 UART"
+
+[dependencies]
+critical-section.workspace = true
+embedded-io.workspace = true
+log.workspace = true
+ast1060-uart-api = { path = "../../drv/ast1060-uart-api" }
+
+[lib]
+test = false
+doctest = false
+bench = false
+
+[lints]
+workspace = true

--- a/lib/ast1060-uart-log/src/lib.rs
+++ b/lib/ast1060-uart-log/src/lib.rs
@@ -1,0 +1,67 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![no_main]
+#![no_std]
+
+use ast1060_uart_api::Uart;
+use core::cell::{OnceCell, RefCell};
+use critical_section::Mutex;
+use embedded_io::Write;
+use log::{Level, Metadata, Record};
+
+static LOGGER: IoWriteLogger = IoWriteLogger::new();
+struct IoWriteLogger {
+    writer: Mutex<RefCell<Option<Uart>>>,
+    level: Mutex<OnceCell<Level>>,
+}
+impl IoWriteLogger {
+    const fn new() -> Self {
+        IoWriteLogger {
+            writer: Mutex::new(RefCell::new(None)),
+            level: Mutex::new(OnceCell::new()),
+        }
+    }
+}
+
+impl log::Log for IoWriteLogger {
+    fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+        critical_section::with(|cs| {
+            metadata.level()
+                <= self.level.borrow(cs).get().cloned().unwrap_or(Level::Info)
+        })
+    }
+    fn log(&self, record: &Record<'_>) {
+        if self.enabled(record.metadata()) {
+            critical_section::with(|cs| {
+                if let Some(uart) = self.writer.borrow(cs).borrow_mut().as_mut()
+                {
+                    uart.write_fmt(format_args!(
+                        "[{}] - {}: {}\n",
+                        record.level(),
+                        record.target(),
+                        record.args()
+                    ))
+                    .ok();
+                }
+            });
+        }
+    }
+    fn flush(&self) {
+        critical_section::with(|cs| {
+            if let Some(uart) = self.writer.borrow(cs).borrow_mut().as_mut() {
+                let _ = uart.flush();
+            }
+        });
+    }
+}
+
+pub fn init(uart: Uart, level: log::Level) -> Result<(), log::SetLoggerError> {
+    critical_section::with(|cs| {
+        LOGGER.writer.borrow(cs).replace(Some(uart));
+        LOGGER.level.borrow(cs).set(level).ok();
+    });
+    log::set_logger(&LOGGER)
+        .map(|()| log::set_max_level(log::LevelFilter::Info))
+}

--- a/task/mctp-server/Cargo.toml
+++ b/task/mctp-server/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ast1060-pac = { workspace = true, features = ["rt"] }
 cortex-m = { workspace = true }
 cortex-m-rt = { workspace = true }
 userlib = { path = "../../sys/userlib", features = ["panic-messages"] }
@@ -18,14 +17,22 @@ zerocopy-derive = { workspace = true }
 mctp-api = { path = "../mctp-api" }
 mctp-stack = { git = "https://github.com/9elements/mctp-lib.git", branch = "buildup", package = "mctp-lib" }
 mctp = { workspace = true }
-lib-ast1060-uart = { path = "../../lib/ast1060-uart" }
+ast1060-uart-api = { path = "../../drv/ast1060-uart-api", optional = true }
 nb = {workspace = true}
 heapless = { workspace = true }
 embedded-io = { workspace = true }
+drv-i2c-api = { path = "../../drv/i2c-api", optional = true }
+ast1060-uart-log = { path = "../../lib/ast1060-uart-log", optional = true }
+log.workspace = true
 
 [build-dependencies]
 idol = { workspace = true }
 build-util = { path = "../../build/util" }
+
+[features]
+transport_serial = ["dep:ast1060-uart-api"]
+transport_i2c = ["dep:drv-i2c-api"]
+serial_log = ["dep:ast1060-uart-api", "dep:ast1060-uart-log"]
 
 # This section is here to discourage RLS/rust-analyzer from doing test builds,
 # since test builds don't work for cross compilation.

--- a/task/mctp-server/src/i2c.rs
+++ b/task/mctp-server/src/i2c.rs
@@ -1,0 +1,73 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+use super::I2C_MAX_EIDS;
+use drv_i2c_api::*;
+use heapless::FnvIndexMap;
+use log::{trace, warn};
+use mctp::{Eid, Result};
+use mctp_stack::i2c::{MctpI2cEncap, MCTP_I2C_MAXMTU};
+use userlib::TaskId;
+
+pub struct I2cSender {
+    i2c_driver_task: TaskId,
+    _neighbor_table: FnvIndexMap<Eid, u8, { I2C_MAX_EIDS as usize }>,
+}
+impl I2cSender {
+    pub fn new(i2c_driver_task: TaskId) -> Self {
+        Self {
+            i2c_driver_task,
+            _neighbor_table: FnvIndexMap::new(),
+        }
+    }
+}
+impl mctp_stack::Sender for I2cSender {
+    fn send_vectored(
+        &mut self,
+        mut fragmenter: mctp_stack::fragment::Fragmenter,
+        payload: &[&[u8]],
+    ) -> Result<mctp::Tag> {
+        // TODO The stack needs to provide the destination EID to the sender
+        // let addr = self
+        //     .neighbor_table
+        //     .get(eid)
+        //     .ok_or(mctp::Error::Unreachable)?;
+        let addr = 0x42;
+        let i2c = I2cDevice::new(
+            self.i2c_driver_task,
+            Controller::I2C1,
+            PortIndex(0),
+            None,
+            addr,
+        );
+        let encoder = MctpI2cEncap::new(super::I2C_OWN_ADDR);
+        loop {
+            let mut pkt = [0u8; mctp_stack::serial::MTU_MAX];
+            let r = fragmenter.fragment_vectored(payload, &mut pkt);
+
+            match r {
+                mctp_stack::fragment::SendOutput::Packet(p) => {
+                    let mut out = [0; MCTP_I2C_MAXMTU + 8]; // max MTU + I2C header size
+                    let packet = encoder.encode(addr, &p, &mut out, true)?;
+                    trace!("I2C MCTP TX: {:02x?}", &packet);
+                    i2c.write(&out).map_err(|e| {
+                        warn!("I2C MCTP TX error: {:?}", e);
+                        mctp::Error::TxFailure
+                    })?;
+                }
+                mctp_stack::fragment::SendOutput::Complete { tag, .. } => {
+                    trace!("I2C MCTP TX Complete");
+                    break Ok(tag);
+                }
+                mctp_stack::fragment::SendOutput::Error { err, .. } => {
+                    warn!("I2C MCTP TX fragmenter error: {:?}", err);
+                    break Err(err);
+                }
+            }
+        }
+    }
+
+    fn get_mtu(&self) -> usize {
+        MCTP_I2C_MAXMTU
+    }
+}

--- a/task/mctp-server/src/server.rs
+++ b/task/mctp-server/src/server.rs
@@ -133,9 +133,6 @@ impl<S: mctp_stack::Sender, const OUTSTANDING: usize> Server<S, OUTSTANDING> {
         ic: bool,
         buf: Leased<R, [u8]>,
     ) {
-        // TODO figure out if handling incoming packets while sending is neccessary.
-        //      Having dedicated driver tasks with buffering for every transport would simplify this.
-
         let mut msg_buf = [0; MAX_PAYLOAD];
         if msg_buf.len() < buf.len() {
             sys_reply(msg.sender, ServerError::NoSpace.into(), &[]);


### PR DESCRIPTION
# I2C API: Add Interrupt-Driven Slave Mode Operations

## Summary

This PR replaces the polling-based I2C slave receive implementation with an interrupt-driven, notification-based design that aligns with Hubris architectural patterns. This change is critical for efficient MCTP (Management Component Transport Protocol) implementation and other peer-to-peer I2C protocols.

## Motivation

The original I2C API used timer-based polling for slave mode message reception, which has several fundamental problems:

**Performance Issues:**
- Wastes CPU cycles polling when no messages are present
- Unpredictable latency between message arrival and processing
- Poor power efficiency (continuous polling prevents sleep states)
- Risk of message loss if hardware buffer fills between poll intervals

**Architectural Issues:**
- Violates Hubris's event-driven, notification-based design patterns
- Polling contradicts the principles used throughout the rest of the system
- Makes MCTP protocol implementation inefficient and unreliable

**MCTP Impact:**
- MCTP requires low-latency message handling for reliable peer-to-peer communication
- Polling introduces delays that can cause protocol timeouts
- Missed messages due to buffer overflow affect protocol reliability

## Changes

### API Additions (drv/i2c-api)

**New Methods:**
- `enable_slave_notification(mask: u32)` - Register for interrupt-driven notifications when messages arrive
- `get_slave_message() -> Result<SlaveMessage>` - Retrieve single message (optimal for interrupt processing)
- `disable_slave_notification()` - Stop receiving notifications

**Deprecated Methods (backward compatible):**
- `check_slave_buffer()` - Polling-based approach (deprecated)
- `get_slave_messages()` - Multi-message polling (deprecated)

### Operation Codes (drv/i2c-types)

**New Operations:**
- `Op::EnableSlaveNotification` (6) - Configure interrupt notifications
- `Op::DisableSlaveNotification` (7) - Disable notifications
- `Op::GetSlaveMessage` (8) - Single message retrieval

**New Error Codes:**
- `ResponseCode::NoSlaveMessage` - No message available in buffer
- `ResponseCode::NotificationFailed` - Failed to register notification with driver

